### PR TITLE
[Feat] 회원가입, 이메일인증, 다이얼로그 구현 #37

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MJCN">

--- a/app/src/main/java/com/ultimatejw/mjcn/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/app/di/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.ultimatejw.mjcn.app.di
 
+import com.ultimatejw.mjcn.data.remote.AuthApiService
 import com.ultimatejw.mjcn.data.remote.MjcnApiService
 import dagger.Module
 import dagger.Provides
@@ -34,7 +35,7 @@ object NetworkModule {
     @Provides
     fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit =
         Retrofit.Builder()
-            .baseUrl("https://api.mjcn.com/") // TODO: 실제 baseUrl로 교체
+            .baseUrl("http://3.34.185.127:8000/")
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
@@ -43,4 +44,9 @@ object NetworkModule {
     @Provides
     fun provideMjcnApiService(retrofit: Retrofit): MjcnApiService =
         retrofit.create(MjcnApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideAuthApiService(retrofit: Retrofit): AuthApiService =
+        retrofit.create(AuthApiService::class.java)
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/app/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/app/di/RepositoryModule.kt
@@ -1,10 +1,12 @@
 package com.ultimatejw.mjcn.app.di
 
+import com.ultimatejw.mjcn.data.repository.AuthRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.BookmarkRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.ChatRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.NoticeRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.NotificationRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.UserRepositoryImpl
+import com.ultimatejw.mjcn.domain.repository.AuthRepository
 import com.ultimatejw.mjcn.domain.repository.BookmarkRepository
 import com.ultimatejw.mjcn.domain.repository.ChatRepository
 import com.ultimatejw.mjcn.domain.repository.NoticeRepository
@@ -39,4 +41,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindNotificationRepository(impl: NotificationRepositoryImpl): NotificationRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindAuthRepository(impl: AuthRepositoryImpl): AuthRepository
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/AuthApiService.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/AuthApiService.kt
@@ -1,0 +1,20 @@
+package com.ultimatejw.mjcn.data.remote
+
+import com.ultimatejw.mjcn.data.remote.dto.auth.ResendVerificationRequest
+import com.ultimatejw.mjcn.data.remote.dto.auth.SignupRequest
+import com.ultimatejw.mjcn.data.remote.dto.auth.VerifyEmailRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthApiService {
+
+    @POST("api/v1/accounts/signup/")
+    suspend fun signup(@Body request: SignupRequest): Response<Unit>
+
+    @POST("api/v1/accounts/verify-email/")
+    suspend fun verifyEmail(@Body request: VerifyEmailRequest): Response<Unit>
+
+    @POST("api/v1/accounts/verify-email/resend/")
+    suspend fun resendVerification(@Body request: ResendVerificationRequest): Response<Unit>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/ResendVerificationRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/ResendVerificationRequest.kt
@@ -1,0 +1,7 @@
+package com.ultimatejw.mjcn.data.remote.dto.auth
+
+import com.google.gson.annotations.SerializedName
+
+data class ResendVerificationRequest(
+    @SerializedName("email") val email: String
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/SignupRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/SignupRequest.kt
@@ -1,0 +1,9 @@
+package com.ultimatejw.mjcn.data.remote.dto.auth
+
+import com.google.gson.annotations.SerializedName
+
+data class SignupRequest(
+    @SerializedName("email") val email: String,
+    @SerializedName("password") val password: String,
+    @SerializedName("password_confirm") val passwordConfirm: String
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/VerifyEmailRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/VerifyEmailRequest.kt
@@ -1,0 +1,8 @@
+package com.ultimatejw.mjcn.data.remote.dto.auth
+
+import com.google.gson.annotations.SerializedName
+
+data class VerifyEmailRequest(
+    @SerializedName("email") val email: String,
+    @SerializedName("code") val code: String
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,51 @@
+package com.ultimatejw.mjcn.data.repository
+
+import com.ultimatejw.mjcn.data.remote.AuthApiService
+import com.ultimatejw.mjcn.data.remote.dto.auth.ResendVerificationRequest
+import com.ultimatejw.mjcn.data.remote.dto.auth.SignupRequest
+import com.ultimatejw.mjcn.data.remote.dto.auth.VerifyEmailRequest
+import com.ultimatejw.mjcn.domain.repository.AuthRepository
+import retrofit2.Response
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(
+    private val authApiService: AuthApiService
+) : AuthRepository {
+
+    override suspend fun signup(
+        email: String,
+        password: String,
+        passwordConfirm: String
+    ): Result<Unit> = runCatching {
+        val response = authApiService.signup(
+            SignupRequest(email = email, password = password, passwordConfirm = passwordConfirm)
+        )
+        response.requireSuccess()
+    }
+
+    override suspend fun verifyEmail(email: String, code: String): Result<Unit> = runCatching {
+        val response = authApiService.verifyEmail(
+            VerifyEmailRequest(email = email, code = code)
+        )
+        response.requireSuccess()
+    }
+
+    override suspend fun resendVerification(email: String): Result<Unit> = runCatching {
+        val response = authApiService.resendVerification(
+            ResendVerificationRequest(email = email)
+        )
+        response.requireSuccess()
+    }
+
+    private fun Response<Unit>.requireSuccess() {
+        if (!isSuccessful) {
+            val errorBody = errorBody()?.string().orEmpty()
+            throw AuthApiException(code = code(), errorBody = errorBody)
+        }
+    }
+}
+
+class AuthApiException(
+    val code: Int,
+    val errorBody: String
+) : RuntimeException("Auth API failed: HTTP $code, body=$errorBody")

--- a/app/src/main/java/com/ultimatejw/mjcn/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/domain/repository/AuthRepository.kt
@@ -1,0 +1,7 @@
+package com.ultimatejw.mjcn.domain.repository
+
+interface AuthRepository {
+    suspend fun signup(email: String, password: String, passwordConfirm: String): Result<Unit>
+    suspend fun verifyEmail(email: String, code: String): Result<Unit>
+    suspend fun resendVerification(email: String): Result<Unit>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpEmailVerifyFragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpEmailVerifyFragment.kt
@@ -1,6 +1,7 @@
 package com.ultimatejw.mjcn.ui.auth.signup
 import dagger.hilt.android.AndroidEntryPoint
 
+import android.graphics.Paint
 import android.os.Bundle
 import android.os.CountDownTimer
 import android.text.Editable
@@ -10,7 +11,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import com.ultimatejw.mjcn.R
 import com.ultimatejw.mjcn.databinding.FragmentSignupEmailVerifyBinding
 
@@ -22,14 +28,12 @@ class SignUpEmailVerifyFragment : Fragment() {
 
     private val viewModel: SignUpViewModel by activityViewModels()
 
-    // 임시 인증 코드 : 1234
-    private val VALID_CODE = "1234"
-
     private var countDownTimer: CountDownTimer? = null
     private var isTimerExpired = false
 
     companion object {
-        private const val TIMER_MILLIS = 30 * 1000L  // 30초 타이머
+        // 인증코드 유효 시간: 3분
+        private const val TIMER_MILLIS = 3 * 60 * 1000L
     }
 
     override fun onCreateView(
@@ -44,42 +48,84 @@ class SignUpEmailVerifyFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupListeners()
+        observeViewModel()
         startTimer()
     }
 
     private fun setupListeners() {
+        // 입력만 있으면 다음 버튼 활성화 (실제 검증은 다음 클릭 시 서버로)
         binding.etCode.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
                 val code = s.toString().trim()
-                val isValid = !isTimerExpired && code == VALID_CODE
-                updateNextButton(isValid)
-                when {
-                    code.isEmpty() -> hideCodeError()
-                    isTimerExpired -> {
-                        showCodeError("인증 코드가 만료되었습니다. 다시 요청해주세요.")
-                        setInputErrorStyle()
-                    }
-                    code != VALID_CODE -> {
-                        showCodeError("인증 코드가 일치하지 않습니다.")
-                        setInputErrorStyle()
-                    }
-                    else -> hideCodeError()
-                }
+                // 입력이 바뀌면 이전 에러 상태 초기화
+                hideCodeError()
+                updateNextButton(code.isNotEmpty() && !viewModel.isVerifyLoading.value)
             }
         })
 
         binding.tvResend.setOnClickListener {
-            binding.etCode.text.clear()
-            hideCodeError()
-            isTimerExpired = false
-            updateNextButton(false)
-            startTimer()
+            flashResendUnderline()
+            viewModel.resendVerification()
         }
 
         binding.btnNext.setOnClickListener {
-            findNavController().navigate(R.id.action_signUpEmailVerify_to_step1)
+            val code = binding.etCode.text.toString().trim()
+            if (code.isEmpty()) return@setOnClickListener
+            if (isTimerExpired) {
+                showCodeError("인증 코드가 만료되었습니다. 다시 요청해주세요.")
+                setInputErrorStyle()
+                return@setOnClickListener
+            }
+            viewModel.verifyEmail(code)
+        }
+    }
+
+    private fun observeViewModel() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.isVerifyLoading.collect { loading ->
+                    val hasInput = binding.etCode.text.toString().trim().isNotEmpty()
+                    updateNextButton(hasInput && !loading)
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.verifyResult.collect { result ->
+                    when (result) {
+                        is VerifyEmailResult.Success -> {
+                            countDownTimer?.cancel()
+                            findNavController().navigate(R.id.action_signUpEmailVerify_to_step1)
+                        }
+                        is VerifyEmailResult.Failure -> {
+                            showCodeError(result.message)
+                            setInputErrorStyle()
+                        }
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.resendResult.collect { result ->
+                    when (result) {
+                        is ResendResult.Success -> {
+                            binding.etCode.text.clear()
+                            hideCodeError()
+                            isTimerExpired = false
+                            updateNextButton(false)
+                            startTimer()
+                        }
+                        is ResendResult.Failure -> {
+                            showCodeError(result.message)
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -95,7 +141,6 @@ class SignUpEmailVerifyFragment : Fragment() {
             override fun onFinish() {
                 binding.tvTimer.text = "0:00"
                 isTimerExpired = true
-                // 타이머 만료 시 코드가 입력되어 있으면 에러
                 val code = binding.etCode.text.toString().trim()
                 if (code.isNotEmpty()) {
                     showCodeError("인증 코드가 만료되었습니다. 다시 요청해주세요.")
@@ -105,9 +150,18 @@ class SignUpEmailVerifyFragment : Fragment() {
         }.start()
     }
 
-    private fun updateNextButton(hasInput: Boolean) {
-        binding.btnNext.isEnabled = hasInput
-        if (hasInput) {
+    private fun flashResendUnderline() {
+        val tv = binding.tvResend
+        tv.paintFlags = tv.paintFlags or Paint.UNDERLINE_TEXT_FLAG
+        viewLifecycleOwner.lifecycleScope.launch {
+            delay(300)
+            _binding?.tvResend?.let { it.paintFlags = it.paintFlags and Paint.UNDERLINE_TEXT_FLAG.inv() }
+        }
+    }
+
+    private fun updateNextButton(enabled: Boolean) {
+        binding.btnNext.isEnabled = enabled
+        if (enabled) {
             binding.btnNext.setBackgroundResource(R.drawable.bg_btn_primary)
             binding.btnNext.setTextColor(requireContext().getColor(R.color.white))
         } else {

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpEmailVerifyFragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpEmailVerifyFragment.kt
@@ -119,6 +119,12 @@ class SignUpEmailVerifyFragment : Fragment() {
                             isTimerExpired = false
                             updateNextButton(false)
                             startTimer()
+                            // dialog_signup_email_sent와 동일한 다이얼로그 표시.
+                            // 확인 버튼은 dismiss만 하면 되므로 결과 리스너는 등록하지 않음.
+                            SignupEmailSentDialog().show(
+                                parentFragmentManager,
+                                SignupEmailSentDialog.TAG
+                            )
                         }
                         is ResendResult.Failure -> {
                             showCodeError(result.message)

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpIdPwFragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpIdPwFragment.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -25,8 +26,8 @@ class SignUpIdPwFragment : Fragment() {
 
     private val viewModel: SignUpViewModel by activityViewModels()
 
-    // 임시 중복 이메일
-    private val DUPLICATE_EMAIL = "pppp@test.com"
+    // 서버에서 중복 응답 받았을 때 해당 이메일을 기억해두고 즉시 에러 노출
+    private var duplicateEmail: String? = null
 
     private var isPasswordVisible = false
     private var isPasswordConfirmVisible = false
@@ -44,22 +45,67 @@ class SignUpIdPwFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         observeViewModel()
         setupListeners()
+        setFragmentResultListener(SignupEmailSentDialog.REQUEST_KEY) { _, _ ->
+            findNavController().navigate(R.id.action_signUpIdPw_to_signUpEmailVerify)
+        }
     }
 
     private fun observeViewModel() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.step2Valid.collect { valid ->
-                    binding.btnNext.isEnabled = valid
-                    if (valid) {
-                        binding.btnNext.setBackgroundResource(R.drawable.bg_btn_primary)
-                        binding.btnNext.setTextColor(requireContext().getColor(R.color.white))
-                    } else {
-                        binding.btnNext.setBackgroundResource(R.drawable.bg_btn_disabled)
-                        binding.btnNext.setTextColor(requireContext().getColor(R.color.text_disabled))
+                    updateNextButtonStyle(valid && !viewModel.isSignupLoading.value)
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.isSignupLoading.collect { loading ->
+                    val canEnable = viewModel.step2Valid.value && !loading
+                    updateNextButtonStyle(canEnable)
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.signupResult.collect { result ->
+                    when (result) {
+                        is SignupResult.Success -> {
+                            SignupEmailSentDialog().show(parentFragmentManager, SignupEmailSentDialog.TAG)
+                        }
+                        is SignupResult.EmailError -> {
+                            duplicateEmail = result.rejectedEmail
+                            binding.etEmail.setBackgroundResource(R.drawable.bg_input_field_error)
+                            showEmailError(result.message)
+                        }
+                        is SignupResult.PasswordError -> {
+                            binding.flPassword.setBackgroundResource(R.drawable.bg_input_field_error)
+                            showPasswordError(result.message)
+                        }
+                        is SignupResult.PasswordConfirmError -> {
+                            binding.flPasswordConfirm.setBackgroundResource(R.drawable.bg_input_field_error)
+                            showPasswordConfirmError(result.message)
+                        }
+                        is SignupResult.GeneralError -> {
+                            binding.etEmail.setBackgroundResource(R.drawable.bg_input_field_error)
+                            showEmailError(result.message)
+                        }
                     }
                 }
             }
+        }
+    }
+
+    private fun updateNextButtonStyle(enabled: Boolean) {
+        binding.btnNext.isEnabled = enabled
+        if (enabled) {
+            binding.btnNext.setBackgroundResource(R.drawable.bg_btn_primary)
+            binding.btnNext.setTextColor(requireContext().getColor(R.color.white))
+        } else {
+            binding.btnNext.setBackgroundResource(R.drawable.bg_btn_disabled)
+            binding.btnNext.setTextColor(requireContext().getColor(R.color.text_disabled))
         }
     }
 
@@ -118,13 +164,13 @@ class SignUpIdPwFragment : Fragment() {
             setPasswordVisibility(binding.etPasswordConfirm, isPasswordConfirmVisible, binding.btnTogglePasswordConfirm)
         }
 
-        // 다음 버튼
+        // 다음 버튼 → 서버에 회원가입 요청 (성공 시 인증코드 발송)
         binding.btnNext.setOnClickListener {
-            if (isFormValid()) {
-                viewModel.email = binding.etEmail.text.toString().trim()
-                viewModel.password = binding.etPassword.text.toString()
-                findNavController().navigate(R.id.action_signUpIdPw_to_signUpEmailVerify)
-            }
+            if (!isFormValid()) return@setOnClickListener
+            val email = binding.etEmail.text.toString().trim()
+            val password = binding.etPassword.text.toString()
+            val passwordConfirm = binding.etPasswordConfirm.text.toString()
+            viewModel.requestSignup(email, password, passwordConfirm)
         }
     }
 
@@ -141,7 +187,7 @@ class SignUpIdPwFragment : Fragment() {
                 binding.etEmail.setBackgroundResource(R.drawable.bg_input_field_error)
                 showEmailError("올바른 이메일 형식으로 입력해주세요.")
             }
-            email == DUPLICATE_EMAIL -> {
+            email == duplicateEmail -> {
                 binding.etEmail.setBackgroundResource(R.drawable.bg_input_field_error)
                 showEmailError("이미 사용 중인 이메일입니다. 다른 이메일을 입력해주세요.")
             }
@@ -153,7 +199,6 @@ class SignUpIdPwFragment : Fragment() {
     }
 
     private fun applyPasswordFieldState() {
-        val email = binding.etEmail.text.toString().trim()
         val password = binding.etPassword.text.toString()
         when {
             password.isEmpty() -> {
@@ -164,12 +209,7 @@ class SignUpIdPwFragment : Fragment() {
                 binding.flPassword.setBackgroundResource(R.drawable.bg_input_field_error)
                 showPasswordError("영문 + 숫자 포함 8자~20자 이내로 입력해주세요.")
             }
-            isPasswordSameAsEmail(password, email) -> {
-                binding.flPassword.setBackgroundResource(R.drawable.bg_input_field_error)
-                showPasswordError("이메일과 동일한 비밀번호는 사용할 수 없습니다.")
-            }
             else -> {
-                // [수정] 정상 입력 → 보라색 테두리 유지
                 binding.flPassword.setBackgroundResource(R.drawable.bg_input_field_active)
                 hidePasswordError()
             }
@@ -201,8 +241,8 @@ class SignUpIdPwFragment : Fragment() {
         val password = binding.etPassword.text.toString()
         val passwordConfirm = binding.etPasswordConfirm.text.toString()
 
-        val emailOk = isEmailFormatValid(email) && email != DUPLICATE_EMAIL
-        val passwordOk = isPasswordFormatValid(password) && !isPasswordSameAsEmail(password, email)
+        val emailOk = isEmailFormatValid(email) && email != duplicateEmail
+        val passwordOk = isPasswordFormatValid(password)
         val confirmOk = password == passwordConfirm && passwordConfirm.isNotEmpty()
 
         viewModel.onStep2Changed(
@@ -216,8 +256,8 @@ class SignUpIdPwFragment : Fragment() {
         val email = binding.etEmail.text.toString().trim()
         val password = binding.etPassword.text.toString()
         val passwordConfirm = binding.etPasswordConfirm.text.toString()
-        return isEmailFormatValid(email) && email != DUPLICATE_EMAIL
-                && isPasswordFormatValid(password) && !isPasswordSameAsEmail(password, email)
+        return isEmailFormatValid(email) && email != duplicateEmail
+                && isPasswordFormatValid(password)
                 && password == passwordConfirm && passwordConfirm.isNotEmpty()
     }
 
@@ -229,10 +269,6 @@ class SignUpIdPwFragment : Fragment() {
     private fun isPasswordFormatValid(password: String): Boolean {
         val regex = Regex("^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$")
         return regex.matches(password)
-    }
-
-    private fun isPasswordSameAsEmail(password: String, email: String): Boolean {
-        return email.isNotEmpty() && password.equals(email, ignoreCase = true)
     }
 
     private fun setPasswordVisibility(

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep1Fragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep1Fragment.kt
@@ -7,6 +7,7 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -46,6 +47,16 @@ class SignUpStep1Fragment : Fragment() {
         observeViewModel()
         setupListeners()
         restoreState()
+        // 이메일 인증 완료 후 들어온 화면이므로 뒤로가기를 차단해 인증 화면으로
+        // 돌아가지 못하게 한다.
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    // 아무 동작도 하지 않음 → 현재 화면 유지
+                }
+            }
+        )
     }
 
     // ViewModel에 저장된 값으로 UI 복원

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpViewModel.kt
@@ -1,14 +1,43 @@
 package com.ultimatejw.mjcn.ui.auth.signup
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.ultimatejw.mjcn.data.repository.AuthApiException
+import com.ultimatejw.mjcn.domain.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+sealed class SignupResult {
+    data object Success : SignupResult()
+    data class EmailError(val message: String, val rejectedEmail: String) : SignupResult()
+    data class PasswordError(val message: String) : SignupResult()
+    data class PasswordConfirmError(val message: String) : SignupResult()
+    data class GeneralError(val message: String) : SignupResult()
+}
+
+sealed class VerifyEmailResult {
+    data object Success : VerifyEmailResult()
+    data class Failure(val message: String) : VerifyEmailResult()
+}
+
+sealed class ResendResult {
+    data object Success : ResendResult()
+    data class Failure(val message: String) : ResendResult()
+}
+
 @HiltViewModel
-class SignUpViewModel @Inject constructor() : ViewModel() {
+class SignUpViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
 
     // Step 1
     var name: String = ""
@@ -80,6 +109,21 @@ class SignUpViewModel @Inject constructor() : ViewModel() {
     private val _majorStepValid = MutableStateFlow(false)
     val majorStepValid: StateFlow<Boolean> = _majorStepValid.asStateFlow()
 
+    private val _isSignupLoading = MutableStateFlow(false)
+    val isSignupLoading: StateFlow<Boolean> = _isSignupLoading.asStateFlow()
+
+    private val _signupResult = Channel<SignupResult>(Channel.BUFFERED)
+    val signupResult = _signupResult.receiveAsFlow()
+
+    private val _isVerifyLoading = MutableStateFlow(false)
+    val isVerifyLoading: StateFlow<Boolean> = _isVerifyLoading.asStateFlow()
+
+    private val _verifyResult = Channel<VerifyEmailResult>(Channel.BUFFERED)
+    val verifyResult = _verifyResult.receiveAsFlow()
+
+    private val _resendResult = Channel<ResendResult>(Channel.BUFFERED)
+    val resendResult = _resendResult.receiveAsFlow()
+
     companion object {
         private val NAME_REGEX = Regex("^[가-힣a-zA-Z]{2,10}$")
         const val OTHER_INTEREST_LABEL = "기타(직접 입력)"
@@ -134,5 +178,100 @@ class SignUpViewModel @Inject constructor() : ViewModel() {
         val otherTextValid = otherTextLen in OTHER_INTEREST_MIN_LENGTH..OTHER_INTEREST_MAX_LENGTH
         // 기타가 선택된 경우 다른 칩 동반 여부와 무관하게 입력 텍스트가 2~100자여야 함
         _step3Valid.value = hasSelection && (!otherSelected || otherTextValid)
+    }
+
+    fun requestSignup(email: String, password: String, passwordConfirm: String) {
+        if (_isSignupLoading.value) return
+        viewModelScope.launch {
+            _isSignupLoading.value = true
+            val result = authRepository.signup(email, password, passwordConfirm)
+            _isSignupLoading.value = false
+            result
+                .onSuccess {
+                    this@SignUpViewModel.email = email
+                    this@SignUpViewModel.password = password
+                    _signupResult.send(SignupResult.Success)
+                }
+                .onFailure { throwable ->
+                    val errorBody = (throwable as? AuthApiException)?.errorBody.orEmpty()
+                    val fallback = throwable.message ?: "회원가입에 실패했습니다."
+                    _signupResult.send(parseSignupErrorBody(errorBody, email, fallback))
+                }
+        }
+    }
+
+    private fun parseSignupErrorBody(body: String, email: String, fallback: String): SignupResult {
+        if (body.isBlank()) return SignupResult.GeneralError(fallback)
+        return try {
+            val json = JsonParser.parseString(body).asJsonObject
+            val emailMsg = json.firstStringIn("email")
+            val passwordMsg = json.firstStringIn("password")
+            val passwordConfirmMsg = json.firstStringIn("password_confirm")
+            val nonFieldMsg = json.firstStringIn("non_field_errors")
+            val detailMsg = json.get("detail")?.takeIf { !it.isJsonNull }?.asString
+            when {
+                emailMsg != null -> SignupResult.EmailError(emailMsg, email)
+                passwordMsg != null -> SignupResult.PasswordError(passwordMsg)
+                passwordConfirmMsg != null -> SignupResult.PasswordConfirmError(passwordConfirmMsg)
+                nonFieldMsg != null -> SignupResult.GeneralError(nonFieldMsg)
+                detailMsg != null -> SignupResult.GeneralError(detailMsg)
+                else -> SignupResult.GeneralError(fallback)
+            }
+        } catch (_: Exception) {
+            SignupResult.GeneralError(fallback)
+        }
+    }
+
+    private fun JsonObject.firstStringIn(key: String): String? {
+        val element = get(key) ?: return null
+        if (element.isJsonNull) return null
+        return when {
+            element.isJsonArray -> (element as JsonArray)
+                .takeIf { it.size() > 0 }
+                ?.get(0)
+                ?.takeIf { !it.isJsonNull }
+                ?.asString
+            element.isJsonPrimitive -> element.asString
+            else -> null
+        }
+    }
+
+    fun verifyEmail(code: String) {
+        if (_isVerifyLoading.value) return
+        val targetEmail = email
+        if (targetEmail.isBlank()) {
+            viewModelScope.launch {
+                _verifyResult.send(VerifyEmailResult.Failure("이메일 정보가 없습니다. 이전 단계부터 다시 진행해주세요."))
+            }
+            return
+        }
+        viewModelScope.launch {
+            _isVerifyLoading.value = true
+            val result = authRepository.verifyEmail(targetEmail, code)
+            _isVerifyLoading.value = false
+            result
+                .onSuccess { _verifyResult.send(VerifyEmailResult.Success) }
+                .onFailure {
+                    _verifyResult.send(VerifyEmailResult.Failure("인증 코드가 일치하지 않습니다."))
+                }
+        }
+    }
+
+    fun resendVerification() {
+        val targetEmail = email
+        if (targetEmail.isBlank()) {
+            viewModelScope.launch {
+                _resendResult.send(ResendResult.Failure("이메일 정보가 없습니다. 이전 단계부터 다시 진행해주세요."))
+            }
+            return
+        }
+        viewModelScope.launch {
+            val result = authRepository.resendVerification(targetEmail)
+            result
+                .onSuccess { _resendResult.send(ResendResult.Success) }
+                .onFailure {
+                    _resendResult.send(ResendResult.Failure("인증 코드 재전송에 실패했습니다."))
+                }
+        }
     }
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignupEmailSentDialog.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignupEmailSentDialog.kt
@@ -1,0 +1,73 @@
+package com.ultimatejw.mjcn.ui.auth.signup
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.util.TypedValue
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Gravity
+import android.view.WindowManager
+import android.widget.Button
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.ultimatejw.mjcn.R
+
+class SignupEmailSentDialog : DialogFragment() {
+
+    companion object {
+        const val REQUEST_KEY = "SignupEmailSentDialog.REQUEST_KEY"
+        const val RESULT_CONFIRMED = "confirmed"
+        const val TAG = "SignupEmailSentDialog"
+
+        private const val HORIZONTAL_MARGIN_DP = 18f
+        // 박스가 187dp일 때 중앙 위치 기준으로, 203dp(16dp 늘림)로 바뀐 후에도
+        // 박스 위쪽이 원래 위치 그대로 유지되도록 박스를 8dp 아래로 내림.
+        private const val VERTICAL_OFFSET_DP = 8f
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.dialog_signup_email_sent, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<Button>(R.id.btn_dialog_confirm).setOnClickListener {
+            setFragmentResult(REQUEST_KEY, bundleOf(RESULT_CONFIRMED to true))
+            dismiss()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.apply {
+            setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            // 뒷배경 어둡게 (스크림)
+            addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+            val params = attributes
+            params.dimAmount = 0.5f
+            params.gravity = Gravity.CENTER
+            params.y = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                VERTICAL_OFFSET_DP,
+                resources.displayMetrics
+            ).toInt()
+            attributes = params
+
+            val marginPx = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                HORIZONTAL_MARGIN_DP,
+                resources.displayMetrics
+            ).toInt()
+            val screenWidth = resources.displayMetrics.widthPixels
+            val width = screenWidth - 2 * marginPx
+            setLayout(width, WindowManager.LayoutParams.WRAP_CONTENT)
+        }
+    }
+}

--- a/app/src/main/res/drawable/bg_dialog_rounded.xml
+++ b/app/src/main/res/drawable/bg_dialog_rounded.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <corners android:radius="32dp" />
+</shape>

--- a/app/src/main/res/layout/dialog_signup_email_sent.xml
+++ b/app/src/main/res/layout/dialog_signup_email_sent.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_dialog_rounded">
+
+    <TextView
+        android:id="@+id/tv_dialog_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="인증 코드를 이메일로 발송했습니다."
+        android:textColor="@color/text_primary"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_dialog_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="18dp"
+        android:text="이메일을 확인해주세요."
+        android:textColor="@color/text_primary"
+        android:textSize="14sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_dialog_title" />
+
+    <Button
+        android:id="@+id/btn_dialog_confirm"
+        android:layout_width="0dp"
+        android:layout_height="52dp"
+        android:layout_marginStart="15dp"
+        android:layout_marginEnd="15dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginBottom="16dp"
+        android:background="@drawable/bg_btn_primary"
+        android:fontFamily="sans-serif-medium"
+        android:text="확인"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_dialog_subtitle"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">3.34.185.127</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
회원가입 첫화면 및 이메일 인증 api 연결 
인증코드 발송 다이얼로그 구현

*회원가입 첫화면에서 이메일과 유사한 비밀번호 입력 시 나오는 메시지에 오타있음(서버에서 고쳐줘야 할듯)