### PR TITLE
회원가입1~5, 로그인 API 연동 #40

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MJCN">

--- a/app/src/main/java/com/ultimatejw/mjcn/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/app/di/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.ultimatejw.mjcn.app.di
 
+import com.ultimatejw.mjcn.data.remote.AuthApiService
 import com.ultimatejw.mjcn.data.remote.MjcnApiService
 import dagger.Module
 import dagger.Provides
@@ -34,7 +35,7 @@ object NetworkModule {
     @Provides
     fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit =
         Retrofit.Builder()
-            .baseUrl("https://api.mjcn.com/") // TODO: 실제 baseUrl로 교체
+            .baseUrl("http://3.34.185.127:8000/")
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
@@ -43,4 +44,9 @@ object NetworkModule {
     @Provides
     fun provideMjcnApiService(retrofit: Retrofit): MjcnApiService =
         retrofit.create(MjcnApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideAuthApiService(retrofit: Retrofit): AuthApiService =
+        retrofit.create(AuthApiService::class.java)
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/app/di/NetworkModule.kt
@@ -1,7 +1,12 @@
 package com.ultimatejw.mjcn.app.di
 
 import com.ultimatejw.mjcn.data.remote.AuthApiService
+import com.ultimatejw.mjcn.data.remote.CourseHistoryApiService
+import com.ultimatejw.mjcn.data.remote.CurrentCourseApiService
+import com.ultimatejw.mjcn.data.remote.InterestApiService
 import com.ultimatejw.mjcn.data.remote.MjcnApiService
+import com.ultimatejw.mjcn.data.remote.ProfileApiService
+import com.ultimatejw.mjcn.data.remote.interceptor.AuthInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,9 +30,12 @@ object NetworkModule {
     @Singleton
     @Provides
     fun provideOkHttpClient(
-        loggingInterceptor: HttpLoggingInterceptor
+        loggingInterceptor: HttpLoggingInterceptor,
+        authInterceptor: AuthInterceptor
     ): OkHttpClient =
         OkHttpClient.Builder()
+            // AuthInterceptor가 먼저 토큰을 붙인 뒤 logging이 그 결과를 로깅하도록 순서 유지.
+            .addInterceptor(authInterceptor)
             .addInterceptor(loggingInterceptor)
             .build()
 
@@ -49,4 +57,24 @@ object NetworkModule {
     @Provides
     fun provideAuthApiService(retrofit: Retrofit): AuthApiService =
         retrofit.create(AuthApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideProfileApiService(retrofit: Retrofit): ProfileApiService =
+        retrofit.create(ProfileApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideInterestApiService(retrofit: Retrofit): InterestApiService =
+        retrofit.create(InterestApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideCourseHistoryApiService(retrofit: Retrofit): CourseHistoryApiService =
+        retrofit.create(CourseHistoryApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideCurrentCourseApiService(retrofit: Retrofit): CurrentCourseApiService =
+        retrofit.create(CurrentCourseApiService::class.java)
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/app/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/app/di/RepositoryModule.kt
@@ -1,10 +1,12 @@
 package com.ultimatejw.mjcn.app.di
 
+import com.ultimatejw.mjcn.data.repository.AuthRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.BookmarkRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.ChatRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.NoticeRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.NotificationRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.UserRepositoryImpl
+import com.ultimatejw.mjcn.domain.repository.AuthRepository
 import com.ultimatejw.mjcn.domain.repository.BookmarkRepository
 import com.ultimatejw.mjcn.domain.repository.ChatRepository
 import com.ultimatejw.mjcn.domain.repository.NoticeRepository
@@ -39,4 +41,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindNotificationRepository(impl: NotificationRepositoryImpl): NotificationRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindAuthRepository(impl: AuthRepositoryImpl): AuthRepository
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/app/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/app/di/RepositoryModule.kt
@@ -3,14 +3,22 @@ package com.ultimatejw.mjcn.app.di
 import com.ultimatejw.mjcn.data.repository.AuthRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.BookmarkRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.ChatRepositoryImpl
+import com.ultimatejw.mjcn.data.repository.CourseHistoryRepositoryImpl
+import com.ultimatejw.mjcn.data.repository.CurrentCourseRepositoryImpl
+import com.ultimatejw.mjcn.data.repository.InterestRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.NoticeRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.NotificationRepositoryImpl
+import com.ultimatejw.mjcn.data.repository.ProfileRepositoryImpl
 import com.ultimatejw.mjcn.data.repository.UserRepositoryImpl
 import com.ultimatejw.mjcn.domain.repository.AuthRepository
 import com.ultimatejw.mjcn.domain.repository.BookmarkRepository
 import com.ultimatejw.mjcn.domain.repository.ChatRepository
+import com.ultimatejw.mjcn.domain.repository.CourseHistoryRepository
+import com.ultimatejw.mjcn.domain.repository.CurrentCourseRepository
+import com.ultimatejw.mjcn.domain.repository.InterestRepository
 import com.ultimatejw.mjcn.domain.repository.NoticeRepository
 import com.ultimatejw.mjcn.domain.repository.NotificationRepository
+import com.ultimatejw.mjcn.domain.repository.ProfileRepository
 import com.ultimatejw.mjcn.domain.repository.UserRepository
 import dagger.Binds
 import dagger.Module
@@ -45,4 +53,20 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindAuthRepository(impl: AuthRepositoryImpl): AuthRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindProfileRepository(impl: ProfileRepositoryImpl): ProfileRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindInterestRepository(impl: InterestRepositoryImpl): InterestRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCourseHistoryRepository(impl: CourseHistoryRepositoryImpl): CourseHistoryRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCurrentCourseRepository(impl: CurrentCourseRepositoryImpl): CurrentCourseRepository
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/data/local/TokenStore.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/local/TokenStore.kt
@@ -1,0 +1,72 @@
+package com.ultimatejw.mjcn.data.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 로그인 토큰과 온보딩 진행 상태를 보관한다.
+ * - 토큰은 OkHttp Interceptor에서 동기 접근이 필요하므로 메모리 캐시(@Volatile)도 유지.
+ * - 진행 상태(is_onboarding_completed)는 SplashActivity 분기에 사용.
+ */
+@Singleton
+class TokenStore @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) {
+    companion object {
+        private val KEY_ACCESS_TOKEN = stringPreferencesKey("auth_access_token")
+        private val KEY_REFRESH_TOKEN = stringPreferencesKey("auth_refresh_token")
+        private val KEY_ONBOARDING_COMPLETED = booleanPreferencesKey("auth_onboarding_completed")
+    }
+
+    @Volatile private var cachedAccess: String? = null
+    @Volatile private var cachedRefresh: String? = null
+
+    init {
+        // Singleton이 처음 주입될 때 1회 동기 로드. 짧은 IO이므로 cold start 시 허용 가능.
+        runBlocking {
+            val prefs = dataStore.data.first()
+            cachedAccess = prefs[KEY_ACCESS_TOKEN]
+            cachedRefresh = prefs[KEY_REFRESH_TOKEN]
+        }
+    }
+
+    fun currentAccessToken(): String? = cachedAccess
+    fun currentRefreshToken(): String? = cachedRefresh
+
+    suspend fun saveTokens(access: String, refresh: String?) {
+        cachedAccess = access
+        cachedRefresh = refresh
+        dataStore.edit { prefs ->
+            prefs[KEY_ACCESS_TOKEN] = access
+            if (refresh != null) prefs[KEY_REFRESH_TOKEN] = refresh
+        }
+    }
+
+    suspend fun clearTokens() {
+        cachedAccess = null
+        cachedRefresh = null
+        dataStore.edit { prefs ->
+            prefs.remove(KEY_ACCESS_TOKEN)
+            prefs.remove(KEY_REFRESH_TOKEN)
+        }
+    }
+
+    suspend fun setOnboardingCompleted(completed: Boolean) {
+        dataStore.edit { prefs -> prefs[KEY_ONBOARDING_COMPLETED] = completed }
+    }
+
+    suspend fun isOnboardingCompleted(): Boolean =
+        dataStore.data.first()[KEY_ONBOARDING_COMPLETED] ?: false
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/AuthApiService.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/AuthApiService.kt
@@ -1,0 +1,20 @@
+package com.ultimatejw.mjcn.data.remote
+
+import com.ultimatejw.mjcn.data.remote.dto.auth.ResendVerificationRequest
+import com.ultimatejw.mjcn.data.remote.dto.auth.SignupRequest
+import com.ultimatejw.mjcn.data.remote.dto.auth.VerifyEmailRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthApiService {
+
+    @POST("api/v1/accounts/signup/")
+    suspend fun signup(@Body request: SignupRequest): Response<Unit>
+
+    @POST("api/v1/accounts/verify-email/")
+    suspend fun verifyEmail(@Body request: VerifyEmailRequest): Response<Unit>
+
+    @POST("api/v1/accounts/verify-email/resend/")
+    suspend fun resendVerification(@Body request: ResendVerificationRequest): Response<Unit>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/AuthApiService.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/AuthApiService.kt
@@ -1,5 +1,7 @@
 package com.ultimatejw.mjcn.data.remote
 
+import com.ultimatejw.mjcn.data.remote.dto.auth.LoginRequest
+import com.ultimatejw.mjcn.data.remote.dto.auth.LoginResponse
 import com.ultimatejw.mjcn.data.remote.dto.auth.ResendVerificationRequest
 import com.ultimatejw.mjcn.data.remote.dto.auth.SignupRequest
 import com.ultimatejw.mjcn.data.remote.dto.auth.VerifyEmailRequest
@@ -17,4 +19,7 @@ interface AuthApiService {
 
     @POST("api/v1/accounts/verify-email/resend/")
     suspend fun resendVerification(@Body request: ResendVerificationRequest): Response<Unit>
+
+    @POST("api/v1/accounts/login/")
+    suspend fun login(@Body request: LoginRequest): Response<LoginResponse>
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/CourseHistoryApiService.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/CourseHistoryApiService.kt
@@ -1,0 +1,12 @@
+package com.ultimatejw.mjcn.data.remote
+
+import com.ultimatejw.mjcn.data.remote.dto.course.CourseHistoryRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface CourseHistoryApiService {
+
+    @POST("api/v1/accounts/course-history/")
+    suspend fun createCourseHistory(@Body request: CourseHistoryRequest): Response<Unit>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/CurrentCourseApiService.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/CurrentCourseApiService.kt
@@ -1,0 +1,12 @@
+package com.ultimatejw.mjcn.data.remote
+
+import com.ultimatejw.mjcn.data.remote.dto.course.CurrentCourseRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface CurrentCourseApiService {
+
+    @POST("api/v1/accounts/current-courses/")
+    suspend fun createCurrentCourse(@Body request: CurrentCourseRequest): Response<Unit>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/InterestApiService.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/InterestApiService.kt
@@ -1,0 +1,18 @@
+package com.ultimatejw.mjcn.data.remote
+
+import com.ultimatejw.mjcn.data.remote.dto.interest.InterestRequest
+import com.ultimatejw.mjcn.data.remote.dto.interest.InterestResponse
+import com.ultimatejw.mjcn.data.remote.dto.interest.PaginatedInterestResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface InterestApiService {
+
+    @GET("api/v1/accounts/interests/")
+    suspend fun listInterests(): Response<PaginatedInterestResponse>
+
+    @POST("api/v1/accounts/interests/")
+    suspend fun createInterest(@Body request: InterestRequest): Response<InterestResponse>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/ProfileApiService.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/ProfileApiService.kt
@@ -1,0 +1,17 @@
+package com.ultimatejw.mjcn.data.remote
+
+import com.ultimatejw.mjcn.data.remote.dto.profile.ProfileResponse
+import com.ultimatejw.mjcn.data.remote.dto.profile.ProfileUpdateRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+
+interface ProfileApiService {
+
+    @GET("api/v1/accounts/profile/")
+    suspend fun getProfile(): Response<ProfileResponse>
+
+    @PATCH("api/v1/accounts/profile/")
+    suspend fun patchProfile(@Body request: ProfileUpdateRequest): Response<ProfileResponse>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/LoginRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/LoginRequest.kt
@@ -1,0 +1,8 @@
+package com.ultimatejw.mjcn.data.remote.dto.auth
+
+import com.google.gson.annotations.SerializedName
+
+data class LoginRequest(
+    @SerializedName("email") val email: String,
+    @SerializedName("password") val password: String
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/LoginResponse.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/LoginResponse.kt
@@ -1,0 +1,12 @@
+package com.ultimatejw.mjcn.data.remote.dto.auth
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * SimpleJWT 응답. 스웨거에 응답 바디가 명시되어 있지 않으므로 access/refresh만 수신.
+ * 추가 필드(user 등)는 무시.
+ */
+data class LoginResponse(
+    @SerializedName("access") val access: String?,
+    @SerializedName("refresh") val refresh: String?
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/ResendVerificationRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/ResendVerificationRequest.kt
@@ -1,0 +1,7 @@
+package com.ultimatejw.mjcn.data.remote.dto.auth
+
+import com.google.gson.annotations.SerializedName
+
+data class ResendVerificationRequest(
+    @SerializedName("email") val email: String
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/SignupRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/SignupRequest.kt
@@ -1,0 +1,9 @@
+package com.ultimatejw.mjcn.data.remote.dto.auth
+
+import com.google.gson.annotations.SerializedName
+
+data class SignupRequest(
+    @SerializedName("email") val email: String,
+    @SerializedName("password") val password: String,
+    @SerializedName("password_confirm") val passwordConfirm: String
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/VerifyEmailRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/auth/VerifyEmailRequest.kt
@@ -1,0 +1,8 @@
+package com.ultimatejw.mjcn.data.remote.dto.auth
+
+import com.google.gson.annotations.SerializedName
+
+data class VerifyEmailRequest(
+    @SerializedName("email") val email: String,
+    @SerializedName("code") val code: String
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/course/CourseHistoryRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/course/CourseHistoryRequest.kt
@@ -1,0 +1,13 @@
+package com.ultimatejw.mjcn.data.remote.dto.course
+
+import com.google.gson.annotations.SerializedName
+
+data class CourseHistoryRequest(
+    @SerializedName("course_name") val courseName: String,
+    @SerializedName("course_code") val courseCode: String,
+    @SerializedName("year") val year: Int,
+    @SerializedName("semester") val semester: Int,
+    @SerializedName("grade_received") val gradeReceived: String = "",
+    @SerializedName("category") val category: String,
+    @SerializedName("credits") val credits: Int
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/course/CurrentCourseRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/course/CurrentCourseRequest.kt
@@ -1,0 +1,14 @@
+package com.ultimatejw.mjcn.data.remote.dto.course
+
+import com.google.gson.annotations.SerializedName
+
+data class CurrentCourseRequest(
+    @SerializedName("course_name") val courseName: String,
+    @SerializedName("course_code") val courseCode: String,
+    @SerializedName("day_of_week") val dayOfWeek: String,
+    @SerializedName("start_time") val startTime: String,
+    @SerializedName("end_time") val endTime: String,
+    @SerializedName("professor") val professor: String = "",
+    @SerializedName("room") val room: String = "",
+    @SerializedName("building") val building: String = ""
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/interest/InterestRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/interest/InterestRequest.kt
@@ -1,0 +1,8 @@
+package com.ultimatejw.mjcn.data.remote.dto.interest
+
+import com.google.gson.annotations.SerializedName
+
+data class InterestRequest(
+    @SerializedName("category") val category: String,
+    @SerializedName("custom_text") val customText: String = ""
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/interest/InterestResponse.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/interest/InterestResponse.kt
@@ -1,0 +1,15 @@
+package com.ultimatejw.mjcn.data.remote.dto.interest
+
+import com.google.gson.annotations.SerializedName
+
+data class InterestResponse(
+    @SerializedName("id") val id: Int,
+    @SerializedName("category") val category: String?,
+    @SerializedName("custom_text") val customText: String?
+)
+
+/** 페이지네이션 응답 (interests GET). 우리는 count 정도만 사용. */
+data class PaginatedInterestResponse(
+    @SerializedName("count") val count: Int = 0,
+    @SerializedName("results") val results: List<InterestResponse> = emptyList()
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/profile/ProfileResponse.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/profile/ProfileResponse.kt
@@ -1,0 +1,18 @@
+package com.ultimatejw.mjcn.data.remote.dto.profile
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * GET/PATCH /api/v1/accounts/profile/ 응답. 모든 필드가 옵셔널.
+ * 온보딩 진행 분기에 사용.
+ */
+data class ProfileResponse(
+    @SerializedName("name") val name: String? = null,
+    @SerializedName("grade") val grade: Int? = null,
+    @SerializedName("semester") val semester: Int? = null,
+    @SerializedName("admission_year") val admissionYear: Int? = null,
+    @SerializedName("graduation_year") val graduationYear: Int? = null,
+    @SerializedName("graduation_month") val graduationMonth: Int? = null,
+    @SerializedName("major") val major: String? = null,
+    @SerializedName("is_onboarding_completed") val isOnboardingCompleted: Boolean? = null
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/profile/ProfileUpdateRequest.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/dto/profile/ProfileUpdateRequest.kt
@@ -1,0 +1,18 @@
+package com.ultimatejw.mjcn.data.remote.dto.profile
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * PATCH /api/v1/accounts/profile/ 요청. 보내고 싶은 필드만 채워서 전송.
+ * Gson은 null 필드를 기본적으로 직렬화하지 않으므로 PATCH의 부분 갱신 의미를 그대로 살린다.
+ */
+data class ProfileUpdateRequest(
+    @SerializedName("name") val name: String? = null,
+    @SerializedName("grade") val grade: Int? = null,
+    @SerializedName("semester") val semester: Int? = null,
+    @SerializedName("admission_year") val admissionYear: Int? = null,
+    @SerializedName("graduation_year") val graduationYear: Int? = null,
+    @SerializedName("graduation_month") val graduationMonth: Int? = null,
+    @SerializedName("major") val major: String? = null,
+    @SerializedName("is_onboarding_completed") val isOnboardingCompleted: Boolean? = null
+)

--- a/app/src/main/java/com/ultimatejw/mjcn/data/remote/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/remote/interceptor/AuthInterceptor.kt
@@ -1,0 +1,31 @@
+package com.ultimatejw.mjcn.data.remote.interceptor
+
+import com.ultimatejw.mjcn.data.local.TokenStore
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 보호된 API 호출에 Authorization: Bearer <access_token> 헤더를 자동 첨부한다.
+ * - 인증이 필요 없는 경로(signup/login/verify-email 등)는 그대로 통과.
+ * - 토큰이 없으면 헤더 미첨부 → 서버에서 401 응답.
+ */
+@Singleton
+class AuthInterceptor @Inject constructor(
+    private val tokenStore: TokenStore
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val original = chain.request()
+        val token = tokenStore.currentAccessToken()
+        val request = if (token.isNullOrBlank()) {
+            original
+        } else {
+            original.newBuilder()
+                .header("Authorization", "Bearer $token")
+                .build()
+        }
+        return chain.proceed(request)
+    }
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/repository/AuthRepositoryImpl.kt
@@ -1,15 +1,20 @@
 package com.ultimatejw.mjcn.data.repository
 
+import com.ultimatejw.mjcn.data.local.TokenStore
 import com.ultimatejw.mjcn.data.remote.AuthApiService
+import com.ultimatejw.mjcn.data.remote.dto.auth.LoginRequest
 import com.ultimatejw.mjcn.data.remote.dto.auth.ResendVerificationRequest
 import com.ultimatejw.mjcn.data.remote.dto.auth.SignupRequest
 import com.ultimatejw.mjcn.data.remote.dto.auth.VerifyEmailRequest
 import com.ultimatejw.mjcn.domain.repository.AuthRepository
+import com.ultimatejw.mjcn.domain.repository.UserRepository
 import retrofit2.Response
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
-    private val authApiService: AuthApiService
+    private val authApiService: AuthApiService,
+    private val tokenStore: TokenStore,
+    private val userRepository: UserRepository
 ) : AuthRepository {
 
     override suspend fun signup(
@@ -35,6 +40,25 @@ class AuthRepositoryImpl @Inject constructor(
             ResendVerificationRequest(email = email)
         )
         response.requireSuccess()
+    }
+
+    override suspend fun login(email: String, password: String): Result<Unit> = runCatching {
+        val response = authApiService.login(LoginRequest(email = email, password = password))
+        if (!response.isSuccessful) {
+            val body = response.errorBody()?.string().orEmpty()
+            throw AuthApiException(code = response.code(), errorBody = body)
+        }
+        val body = response.body() ?: throw AuthApiException(
+            code = response.code(),
+            errorBody = "로그인 응답이 비어있습니다."
+        )
+        val access = body.access ?: throw AuthApiException(
+            code = response.code(),
+            errorBody = "access 토큰이 없습니다."
+        )
+        tokenStore.saveTokens(access = access, refresh = body.refresh)
+        // 로컬 isLoggedIn 플래그도 함께 마킹 → 스플래시/온보딩 재개 분기에 사용.
+        userRepository.saveLoginState(access)
     }
 
     private fun Response<Unit>.requireSuccess() {

--- a/app/src/main/java/com/ultimatejw/mjcn/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,51 @@
+package com.ultimatejw.mjcn.data.repository
+
+import com.ultimatejw.mjcn.data.remote.AuthApiService
+import com.ultimatejw.mjcn.data.remote.dto.auth.ResendVerificationRequest
+import com.ultimatejw.mjcn.data.remote.dto.auth.SignupRequest
+import com.ultimatejw.mjcn.data.remote.dto.auth.VerifyEmailRequest
+import com.ultimatejw.mjcn.domain.repository.AuthRepository
+import retrofit2.Response
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(
+    private val authApiService: AuthApiService
+) : AuthRepository {
+
+    override suspend fun signup(
+        email: String,
+        password: String,
+        passwordConfirm: String
+    ): Result<Unit> = runCatching {
+        val response = authApiService.signup(
+            SignupRequest(email = email, password = password, passwordConfirm = passwordConfirm)
+        )
+        response.requireSuccess()
+    }
+
+    override suspend fun verifyEmail(email: String, code: String): Result<Unit> = runCatching {
+        val response = authApiService.verifyEmail(
+            VerifyEmailRequest(email = email, code = code)
+        )
+        response.requireSuccess()
+    }
+
+    override suspend fun resendVerification(email: String): Result<Unit> = runCatching {
+        val response = authApiService.resendVerification(
+            ResendVerificationRequest(email = email)
+        )
+        response.requireSuccess()
+    }
+
+    private fun Response<Unit>.requireSuccess() {
+        if (!isSuccessful) {
+            val errorBody = errorBody()?.string().orEmpty()
+            throw AuthApiException(code = code(), errorBody = errorBody)
+        }
+    }
+}
+
+class AuthApiException(
+    val code: Int,
+    val errorBody: String
+) : RuntimeException("Auth API failed: HTTP $code, body=$errorBody")

--- a/app/src/main/java/com/ultimatejw/mjcn/data/repository/CourseHistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/repository/CourseHistoryRepositoryImpl.kt
@@ -1,0 +1,36 @@
+package com.ultimatejw.mjcn.data.repository
+
+import com.ultimatejw.mjcn.data.remote.CourseHistoryApiService
+import com.ultimatejw.mjcn.data.remote.dto.course.CourseHistoryRequest
+import com.ultimatejw.mjcn.domain.repository.CourseHistoryRepository
+import javax.inject.Inject
+
+class CourseHistoryRepositoryImpl @Inject constructor(
+    private val api: CourseHistoryApiService
+) : CourseHistoryRepository {
+
+    override suspend fun createCourseHistory(
+        courseName: String,
+        courseCode: String,
+        year: Int,
+        semester: Int,
+        gradeReceived: String,
+        category: String,
+        credits: Int
+    ): Result<Unit> = runCatching {
+        val response = api.createCourseHistory(
+            CourseHistoryRequest(
+                courseName = courseName,
+                courseCode = courseCode,
+                year = year,
+                semester = semester,
+                gradeReceived = gradeReceived,
+                category = category,
+                credits = credits
+            )
+        )
+        if (!response.isSuccessful) {
+            throw AuthApiException(response.code(), response.errorBody()?.string().orEmpty())
+        }
+    }
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/repository/CurrentCourseRepositoryImpl.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/repository/CurrentCourseRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package com.ultimatejw.mjcn.data.repository
+
+import com.ultimatejw.mjcn.data.remote.CurrentCourseApiService
+import com.ultimatejw.mjcn.data.remote.dto.course.CurrentCourseRequest
+import com.ultimatejw.mjcn.domain.repository.CurrentCourseRepository
+import javax.inject.Inject
+
+class CurrentCourseRepositoryImpl @Inject constructor(
+    private val api: CurrentCourseApiService
+) : CurrentCourseRepository {
+
+    override suspend fun createCurrentCourse(
+        courseName: String,
+        courseCode: String,
+        dayOfWeek: String,
+        startTime: String,
+        endTime: String,
+        professor: String,
+        room: String,
+        building: String
+    ): Result<Unit> = runCatching {
+        val response = api.createCurrentCourse(
+            CurrentCourseRequest(
+                courseName = courseName,
+                courseCode = courseCode,
+                dayOfWeek = dayOfWeek,
+                startTime = startTime,
+                endTime = endTime,
+                professor = professor,
+                room = room,
+                building = building
+            )
+        )
+        if (!response.isSuccessful) {
+            throw AuthApiException(response.code(), response.errorBody()?.string().orEmpty())
+        }
+    }
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/repository/InterestRepositoryImpl.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/repository/InterestRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.ultimatejw.mjcn.data.repository
+
+import com.ultimatejw.mjcn.data.remote.InterestApiService
+import com.ultimatejw.mjcn.data.remote.dto.interest.InterestRequest
+import com.ultimatejw.mjcn.domain.repository.InterestRepository
+import javax.inject.Inject
+
+class InterestRepositoryImpl @Inject constructor(
+    private val interestApiService: InterestApiService
+) : InterestRepository {
+
+    override suspend fun createInterest(category: String, customText: String): Result<Unit> = runCatching {
+        val response = interestApiService.createInterest(
+            InterestRequest(category = category, customText = customText)
+        )
+        if (!response.isSuccessful) {
+            throw AuthApiException(response.code(), response.errorBody()?.string().orEmpty())
+        }
+    }
+
+    override suspend fun countInterests(): Result<Int> = runCatching {
+        val response = interestApiService.listInterests()
+        if (!response.isSuccessful) {
+            throw AuthApiException(response.code(), response.errorBody()?.string().orEmpty())
+        }
+        response.body()?.count ?: 0
+    }
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/data/repository/ProfileRepositoryImpl.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/data/repository/ProfileRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package com.ultimatejw.mjcn.data.repository
+
+import com.ultimatejw.mjcn.data.remote.ProfileApiService
+import com.ultimatejw.mjcn.data.remote.dto.profile.ProfileResponse
+import com.ultimatejw.mjcn.data.remote.dto.profile.ProfileUpdateRequest
+import com.ultimatejw.mjcn.domain.repository.ProfileRepository
+import javax.inject.Inject
+
+class ProfileRepositoryImpl @Inject constructor(
+    private val profileApiService: ProfileApiService
+) : ProfileRepository {
+
+    override suspend fun getProfile(): Result<ProfileResponse> = runCatching {
+        val response = profileApiService.getProfile()
+        if (!response.isSuccessful) {
+            throw AuthApiException(response.code(), response.errorBody()?.string().orEmpty())
+        }
+        response.body() ?: ProfileResponse()
+    }
+
+    override suspend fun patchProfile(
+        name: String?,
+        grade: Int?,
+        semester: Int?,
+        admissionYear: Int?,
+        graduationYear: Int?,
+        graduationMonth: Int?,
+        major: String?,
+        isOnboardingCompleted: Boolean?
+    ): Result<Unit> = runCatching {
+        val response = profileApiService.patchProfile(
+            ProfileUpdateRequest(
+                name = name,
+                grade = grade,
+                semester = semester,
+                admissionYear = admissionYear,
+                graduationYear = graduationYear,
+                graduationMonth = graduationMonth,
+                major = major,
+                isOnboardingCompleted = isOnboardingCompleted
+            )
+        )
+        if (!response.isSuccessful) {
+            throw AuthApiException(response.code(), response.errorBody()?.string().orEmpty())
+        }
+    }
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/domain/repository/AuthRepository.kt
@@ -4,4 +4,6 @@ interface AuthRepository {
     suspend fun signup(email: String, password: String, passwordConfirm: String): Result<Unit>
     suspend fun verifyEmail(email: String, code: String): Result<Unit>
     suspend fun resendVerification(email: String): Result<Unit>
+    /** 성공 시 access/refresh 토큰을 TokenStore에 저장한다. */
+    suspend fun login(email: String, password: String): Result<Unit>
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/domain/repository/AuthRepository.kt
@@ -1,0 +1,7 @@
+package com.ultimatejw.mjcn.domain.repository
+
+interface AuthRepository {
+    suspend fun signup(email: String, password: String, passwordConfirm: String): Result<Unit>
+    suspend fun verifyEmail(email: String, code: String): Result<Unit>
+    suspend fun resendVerification(email: String): Result<Unit>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/domain/repository/CourseHistoryRepository.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/domain/repository/CourseHistoryRepository.kt
@@ -1,0 +1,13 @@
+package com.ultimatejw.mjcn.domain.repository
+
+interface CourseHistoryRepository {
+    suspend fun createCourseHistory(
+        courseName: String,
+        courseCode: String,
+        year: Int,
+        semester: Int,
+        gradeReceived: String,
+        category: String,
+        credits: Int
+    ): Result<Unit>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/domain/repository/CurrentCourseRepository.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/domain/repository/CurrentCourseRepository.kt
@@ -1,0 +1,14 @@
+package com.ultimatejw.mjcn.domain.repository
+
+interface CurrentCourseRepository {
+    suspend fun createCurrentCourse(
+        courseName: String,
+        courseCode: String,
+        dayOfWeek: String,
+        startTime: String,
+        endTime: String,
+        professor: String,
+        room: String,
+        building: String
+    ): Result<Unit>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/domain/repository/InterestRepository.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/domain/repository/InterestRepository.kt
@@ -1,0 +1,9 @@
+package com.ultimatejw.mjcn.domain.repository
+
+interface InterestRepository {
+    /** 관심분야 1건 등록. */
+    suspend fun createInterest(category: String, customText: String): Result<Unit>
+
+    /** 현재 등록된 관심분야 개수 (온보딩 재개 분기용). */
+    suspend fun countInterests(): Result<Int>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/domain/repository/ProfileRepository.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/domain/repository/ProfileRepository.kt
@@ -1,0 +1,23 @@
+package com.ultimatejw.mjcn.domain.repository
+
+import com.ultimatejw.mjcn.data.remote.dto.profile.ProfileResponse
+
+interface ProfileRepository {
+    /** 현재 프로필 조회 (온보딩 재개 분기에 사용). */
+    suspend fun getProfile(): Result<ProfileResponse>
+
+    /**
+     * Step1+2 묶음 저장. nullable 파라미터는 보내지 않음.
+     * @param major 대학·학부·전공을 합친 문자열(서버 필드 1개).
+     */
+    suspend fun patchProfile(
+        name: String? = null,
+        grade: Int? = null,
+        semester: Int? = null,
+        admissionYear: Int? = null,
+        graduationYear: Int? = null,
+        graduationMonth: Int? = null,
+        major: String? = null,
+        isOnboardingCompleted: Boolean? = null
+    ): Result<Unit>
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/LoginFragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/LoginFragment.kt
@@ -65,6 +65,7 @@ class LoginFragment : Fragment() {
                 viewModel.event.collect { event ->
                     when (event) {
                         is LoginEvent.NavigateToMain -> navigateToMain()
+                        is LoginEvent.NavigateToStep -> navigateToStep(event.step)
                         is LoginEvent.ShowError -> showToast(event.message)
                     }
                 }
@@ -117,6 +118,18 @@ class LoginFragment : Fragment() {
         val intent = Intent(requireContext(), MainActivity::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         startActivity(intent)
+    }
+
+    /** 온보딩 미완료 사용자를 멈춘 단계로 보낸다. step=2는 step1과 묶여 저장되므로 step1로 간주. */
+    private fun navigateToStep(step: Int) {
+        val actionId = when (step) {
+            1, 2 -> R.id.action_login_to_step1
+            3 -> R.id.action_login_to_step3
+            4 -> R.id.action_login_to_step4
+            5 -> R.id.action_login_to_step5
+            else -> R.id.action_login_to_step1
+        }
+        findNavController().navigate(actionId)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/LoginViewModel.kt
@@ -4,7 +4,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.ultimatejw.mjcn.domain.usecase.user.SaveLoginStateUseCase
+import com.ultimatejw.mjcn.data.local.TokenStore
+import com.ultimatejw.mjcn.data.repository.AuthApiException
+import com.ultimatejw.mjcn.domain.repository.AuthRepository
+import com.ultimatejw.mjcn.domain.repository.ProfileRepository
 import com.ultimatejw.mjcn.utils.isValidEmail
 import com.ultimatejw.mjcn.utils.isValidPassword
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,7 +18,10 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 sealed class LoginEvent {
+    /** 온보딩 완료된 사용자 — 메인으로 이동. */
     data object NavigateToMain : LoginEvent()
+    /** 온보딩 재개 — 멈춘 지점부터 시작. */
+    data class NavigateToStep(val step: Int) : LoginEvent()
     data class ShowError(val message: String) : LoginEvent()
 }
 
@@ -28,7 +34,9 @@ data class LoginUiState(
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val saveLoginState: SaveLoginStateUseCase,
+    private val authRepository: AuthRepository,
+    private val profileRepository: ProfileRepository,
+    private val tokenStore: TokenStore,
 ) : ViewModel() {
 
     private val _event = MutableSharedFlow<LoginEvent>()
@@ -63,13 +71,46 @@ class LoginViewModel @Inject constructor(
         _uiState.value = _uiState.value!!.copy(isLoading = true)
         viewModelScope.launch {
             try {
-                saveLoginState("dummy_token") // TODO: 실제 API 연동
-                _event.emit(LoginEvent.NavigateToMain)
+                val loginResult = authRepository.login(email, password)
+                if (loginResult.isFailure) {
+                    val msg = friendlyMessage(loginResult.exceptionOrNull()!!)
+                    _event.emit(LoginEvent.ShowError(msg))
+                    return@launch
+                }
+                // 토큰/isLoggedIn 마킹은 AuthRepository 가 처리.
+                // 여기서는 온보딩 진행 상태만 판단.
+                val event = determineResumeTarget()
+                _event.emit(event)
             } catch (e: Exception) {
                 _event.emit(LoginEvent.ShowError("로그인에 실패했습니다."))
             } finally {
                 _uiState.postValue(_uiState.value!!.copy(isLoading = false))
             }
+        }
+    }
+
+    /**
+     * 로그인 후 어디로 보낼지 결정.
+     * Step1~5 저장은 Step5 "다음" 클릭 시 일괄로만 이뤄지기 때문에 중간 단계 부분 저장이 없다.
+     * 따라서 분기는 단순히 onboarding 완료 여부만 본다.
+     * - is_onboarding_completed=true → Main
+     * - 그 외 모든 경우(부분 진행/이탈/실패) → Step1 부터 다시 입력
+     */
+    private suspend fun determineResumeTarget(): LoginEvent {
+        val profile = profileRepository.getProfile().getOrNull()
+        if (profile?.isOnboardingCompleted == true) {
+            tokenStore.setOnboardingCompleted(true)
+            return LoginEvent.NavigateToMain
+        }
+        return LoginEvent.NavigateToStep(1)
+    }
+
+    private fun friendlyMessage(t: Throwable): String {
+        val api = t as? AuthApiException ?: return t.message ?: "로그인에 실패했습니다."
+        return when (api.code) {
+            400, 401 -> "이메일 또는 비밀번호가 올바르지 않습니다."
+            403 -> "이메일 인증 후 다시 시도해주세요."
+            else -> "로그인에 실패했습니다. (HTTP ${api.code})"
         }
     }
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/Course.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/Course.kt
@@ -1,5 +1,8 @@
 package com.ultimatejw.mjcn.ui.auth.signup
 
+/** 성적 대신 이수 횟수를 입력해야 하는 특수 과목(채플)의 이름. */
+const val CHAPEL_COURSE_NAME = "채플"
+
 /**
  * 수강 이력/현재 수강 과목 화면에서 표시할 과목 정보.
  * @param code 학수번호 등 과목명 앞에 붙는 접두 코드. 비어있으면 카드에는 과목명만 표시된다.
@@ -10,8 +13,9 @@ data class Course(
     val code: String = ""
 )
 
-/** 사용자가 선택한 과목과 (선택적으로) 성적 */
+/** 사용자가 선택한 과목과 (선택적으로) 성적. meta는 전공/교양 분류 판단용. */
 data class SelectedCourse(
     val name: String,
-    var grade: String? = null
+    var grade: String? = null,
+    val meta: String = ""
 )

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/CourseAdapter.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/CourseAdapter.kt
@@ -57,9 +57,18 @@ class CourseAdapter(
         if (isSelected && showGradeOnSelect) {
             holder.tvGrade.visibility = View.VISIBLE
             val grade = selection?.grade
+            val context = holder.itemView.context
+            val isChapel = course.name == CHAPEL_COURSE_NAME
             if (grade.isNullOrEmpty()) {
                 holder.tvGrade.text = ""
-                holder.tvGrade.hint = holder.itemView.context.getString(R.string.signup_course_grade_hint)
+                if (isChapel) {
+                    // 채플은 성적이 아닌 이수 횟수를 입력해야 하므로 빨간 필수 힌트를 노출
+                    holder.tvGrade.hint = context.getString(R.string.signup_chapel_count_hint)
+                    holder.tvGrade.setHintTextColor(context.getColor(R.color.error))
+                } else {
+                    holder.tvGrade.hint = context.getString(R.string.signup_course_grade_hint)
+                    holder.tvGrade.setHintTextColor(0xFFCCCCCC.toInt())
+                }
                 holder.tvGrade.setBackgroundResource(R.drawable.bg_search_field)
             } else {
                 holder.tvGrade.text = grade

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpEmailVerifyFragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpEmailVerifyFragment.kt
@@ -1,6 +1,7 @@
 package com.ultimatejw.mjcn.ui.auth.signup
 import dagger.hilt.android.AndroidEntryPoint
 
+import android.graphics.Paint
 import android.os.Bundle
 import android.os.CountDownTimer
 import android.text.Editable
@@ -10,7 +11,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import com.ultimatejw.mjcn.R
 import com.ultimatejw.mjcn.databinding.FragmentSignupEmailVerifyBinding
 
@@ -22,14 +28,12 @@ class SignUpEmailVerifyFragment : Fragment() {
 
     private val viewModel: SignUpViewModel by activityViewModels()
 
-    // 임시 인증 코드 : 1234
-    private val VALID_CODE = "1234"
-
     private var countDownTimer: CountDownTimer? = null
     private var isTimerExpired = false
 
     companion object {
-        private const val TIMER_MILLIS = 30 * 1000L  // 30초 타이머
+        // 인증코드 유효 시간: 3분
+        private const val TIMER_MILLIS = 3 * 60 * 1000L
     }
 
     override fun onCreateView(
@@ -44,42 +48,84 @@ class SignUpEmailVerifyFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupListeners()
+        observeViewModel()
         startTimer()
     }
 
     private fun setupListeners() {
+        // 입력만 있으면 다음 버튼 활성화 (실제 검증은 다음 클릭 시 서버로)
         binding.etCode.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
                 val code = s.toString().trim()
-                val isValid = !isTimerExpired && code == VALID_CODE
-                updateNextButton(isValid)
-                when {
-                    code.isEmpty() -> hideCodeError()
-                    isTimerExpired -> {
-                        showCodeError("인증 코드가 만료되었습니다. 다시 요청해주세요.")
-                        setInputErrorStyle()
-                    }
-                    code != VALID_CODE -> {
-                        showCodeError("인증 코드가 일치하지 않습니다.")
-                        setInputErrorStyle()
-                    }
-                    else -> hideCodeError()
-                }
+                // 입력이 바뀌면 이전 에러 상태 초기화
+                hideCodeError()
+                updateNextButton(code.isNotEmpty() && !viewModel.isVerifyLoading.value)
             }
         })
 
         binding.tvResend.setOnClickListener {
-            binding.etCode.text.clear()
-            hideCodeError()
-            isTimerExpired = false
-            updateNextButton(false)
-            startTimer()
+            flashResendUnderline()
+            viewModel.resendVerification()
         }
 
         binding.btnNext.setOnClickListener {
-            findNavController().navigate(R.id.action_signUpEmailVerify_to_step1)
+            val code = binding.etCode.text.toString().trim()
+            if (code.isEmpty()) return@setOnClickListener
+            if (isTimerExpired) {
+                showCodeError("인증 코드가 만료되었습니다. 다시 요청해주세요.")
+                setInputErrorStyle()
+                return@setOnClickListener
+            }
+            viewModel.verifyEmail(code)
+        }
+    }
+
+    private fun observeViewModel() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.isVerifyLoading.collect { loading ->
+                    val hasInput = binding.etCode.text.toString().trim().isNotEmpty()
+                    updateNextButton(hasInput && !loading)
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.verifyResult.collect { result ->
+                    when (result) {
+                        is VerifyEmailResult.Success -> {
+                            countDownTimer?.cancel()
+                            findNavController().navigate(R.id.action_signUpEmailVerify_to_step1)
+                        }
+                        is VerifyEmailResult.Failure -> {
+                            showCodeError(result.message)
+                            setInputErrorStyle()
+                        }
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.resendResult.collect { result ->
+                    when (result) {
+                        is ResendResult.Success -> {
+                            binding.etCode.text.clear()
+                            hideCodeError()
+                            isTimerExpired = false
+                            updateNextButton(false)
+                            startTimer()
+                        }
+                        is ResendResult.Failure -> {
+                            showCodeError(result.message)
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -95,7 +141,6 @@ class SignUpEmailVerifyFragment : Fragment() {
             override fun onFinish() {
                 binding.tvTimer.text = "0:00"
                 isTimerExpired = true
-                // 타이머 만료 시 코드가 입력되어 있으면 에러
                 val code = binding.etCode.text.toString().trim()
                 if (code.isNotEmpty()) {
                     showCodeError("인증 코드가 만료되었습니다. 다시 요청해주세요.")
@@ -105,9 +150,18 @@ class SignUpEmailVerifyFragment : Fragment() {
         }.start()
     }
 
-    private fun updateNextButton(hasInput: Boolean) {
-        binding.btnNext.isEnabled = hasInput
-        if (hasInput) {
+    private fun flashResendUnderline() {
+        val tv = binding.tvResend
+        tv.paintFlags = tv.paintFlags or Paint.UNDERLINE_TEXT_FLAG
+        viewLifecycleOwner.lifecycleScope.launch {
+            delay(300)
+            _binding?.tvResend?.let { it.paintFlags = it.paintFlags and Paint.UNDERLINE_TEXT_FLAG.inv() }
+        }
+    }
+
+    private fun updateNextButton(enabled: Boolean) {
+        binding.btnNext.isEnabled = enabled
+        if (enabled) {
             binding.btnNext.setBackgroundResource(R.drawable.bg_btn_primary)
             binding.btnNext.setTextColor(requireContext().getColor(R.color.white))
         } else {

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpEmailVerifyFragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpEmailVerifyFragment.kt
@@ -98,12 +98,27 @@ class SignUpEmailVerifyFragment : Fragment() {
                     when (result) {
                         is VerifyEmailResult.Success -> {
                             countDownTimer?.cancel()
-                            findNavController().navigate(R.id.action_signUpEmailVerify_to_step1)
+                            // 인증 성공 즉시 자동 로그인을 시도해 JWT를 발급받는다.
+                            // 토큰이 있어야 Step1 이후의 PATCH/POST 요청이 통과한다.
+                            viewModel.performAutoLogin()
                         }
                         is VerifyEmailResult.Failure -> {
                             showCodeError(result.message)
                             setInputErrorStyle()
                         }
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.autoLoginResult.collect { result ->
+                    when (result) {
+                        is AutoLoginResult.Success ->
+                            findNavController().navigate(R.id.action_signUpEmailVerify_to_step1)
+                        is AutoLoginResult.Failure ->
+                            showCodeError(result.message)
                     }
                 }
             }

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpEmailVerifyFragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpEmailVerifyFragment.kt
@@ -119,6 +119,12 @@ class SignUpEmailVerifyFragment : Fragment() {
                             isTimerExpired = false
                             updateNextButton(false)
                             startTimer()
+                            // dialog_signup_email_sent와 동일한 다이얼로그 표시.
+                            // 확인 버튼은 dismiss만 하면 되므로 결과 리스너는 등록하지 않음.
+                            SignupEmailSentDialog().show(
+                                parentFragmentManager,
+                                SignupEmailSentDialog.TAG
+                            )
                         }
                         is ResendResult.Failure -> {
                             showCodeError(result.message)

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpIdPwFragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpIdPwFragment.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -25,8 +26,8 @@ class SignUpIdPwFragment : Fragment() {
 
     private val viewModel: SignUpViewModel by activityViewModels()
 
-    // 임시 중복 이메일
-    private val DUPLICATE_EMAIL = "pppp@test.com"
+    // 서버에서 중복 응답 받았을 때 해당 이메일을 기억해두고 즉시 에러 노출
+    private var duplicateEmail: String? = null
 
     private var isPasswordVisible = false
     private var isPasswordConfirmVisible = false
@@ -44,22 +45,67 @@ class SignUpIdPwFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         observeViewModel()
         setupListeners()
+        setFragmentResultListener(SignupEmailSentDialog.REQUEST_KEY) { _, _ ->
+            findNavController().navigate(R.id.action_signUpIdPw_to_signUpEmailVerify)
+        }
     }
 
     private fun observeViewModel() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.step2Valid.collect { valid ->
-                    binding.btnNext.isEnabled = valid
-                    if (valid) {
-                        binding.btnNext.setBackgroundResource(R.drawable.bg_btn_primary)
-                        binding.btnNext.setTextColor(requireContext().getColor(R.color.white))
-                    } else {
-                        binding.btnNext.setBackgroundResource(R.drawable.bg_btn_disabled)
-                        binding.btnNext.setTextColor(requireContext().getColor(R.color.text_disabled))
+                    updateNextButtonStyle(valid && !viewModel.isSignupLoading.value)
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.isSignupLoading.collect { loading ->
+                    val canEnable = viewModel.step2Valid.value && !loading
+                    updateNextButtonStyle(canEnable)
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.signupResult.collect { result ->
+                    when (result) {
+                        is SignupResult.Success -> {
+                            SignupEmailSentDialog().show(parentFragmentManager, SignupEmailSentDialog.TAG)
+                        }
+                        is SignupResult.EmailError -> {
+                            duplicateEmail = result.rejectedEmail
+                            binding.etEmail.setBackgroundResource(R.drawable.bg_input_field_error)
+                            showEmailError(result.message)
+                        }
+                        is SignupResult.PasswordError -> {
+                            binding.flPassword.setBackgroundResource(R.drawable.bg_input_field_error)
+                            showPasswordError(result.message)
+                        }
+                        is SignupResult.PasswordConfirmError -> {
+                            binding.flPasswordConfirm.setBackgroundResource(R.drawable.bg_input_field_error)
+                            showPasswordConfirmError(result.message)
+                        }
+                        is SignupResult.GeneralError -> {
+                            binding.etEmail.setBackgroundResource(R.drawable.bg_input_field_error)
+                            showEmailError(result.message)
+                        }
                     }
                 }
             }
+        }
+    }
+
+    private fun updateNextButtonStyle(enabled: Boolean) {
+        binding.btnNext.isEnabled = enabled
+        if (enabled) {
+            binding.btnNext.setBackgroundResource(R.drawable.bg_btn_primary)
+            binding.btnNext.setTextColor(requireContext().getColor(R.color.white))
+        } else {
+            binding.btnNext.setBackgroundResource(R.drawable.bg_btn_disabled)
+            binding.btnNext.setTextColor(requireContext().getColor(R.color.text_disabled))
         }
     }
 
@@ -118,13 +164,13 @@ class SignUpIdPwFragment : Fragment() {
             setPasswordVisibility(binding.etPasswordConfirm, isPasswordConfirmVisible, binding.btnTogglePasswordConfirm)
         }
 
-        // 다음 버튼
+        // 다음 버튼 → 서버에 회원가입 요청 (성공 시 인증코드 발송)
         binding.btnNext.setOnClickListener {
-            if (isFormValid()) {
-                viewModel.email = binding.etEmail.text.toString().trim()
-                viewModel.password = binding.etPassword.text.toString()
-                findNavController().navigate(R.id.action_signUpIdPw_to_signUpEmailVerify)
-            }
+            if (!isFormValid()) return@setOnClickListener
+            val email = binding.etEmail.text.toString().trim()
+            val password = binding.etPassword.text.toString()
+            val passwordConfirm = binding.etPasswordConfirm.text.toString()
+            viewModel.requestSignup(email, password, passwordConfirm)
         }
     }
 
@@ -141,7 +187,7 @@ class SignUpIdPwFragment : Fragment() {
                 binding.etEmail.setBackgroundResource(R.drawable.bg_input_field_error)
                 showEmailError("올바른 이메일 형식으로 입력해주세요.")
             }
-            email == DUPLICATE_EMAIL -> {
+            email == duplicateEmail -> {
                 binding.etEmail.setBackgroundResource(R.drawable.bg_input_field_error)
                 showEmailError("이미 사용 중인 이메일입니다. 다른 이메일을 입력해주세요.")
             }
@@ -153,7 +199,6 @@ class SignUpIdPwFragment : Fragment() {
     }
 
     private fun applyPasswordFieldState() {
-        val email = binding.etEmail.text.toString().trim()
         val password = binding.etPassword.text.toString()
         when {
             password.isEmpty() -> {
@@ -164,12 +209,7 @@ class SignUpIdPwFragment : Fragment() {
                 binding.flPassword.setBackgroundResource(R.drawable.bg_input_field_error)
                 showPasswordError("영문 + 숫자 포함 8자~20자 이내로 입력해주세요.")
             }
-            isPasswordSameAsEmail(password, email) -> {
-                binding.flPassword.setBackgroundResource(R.drawable.bg_input_field_error)
-                showPasswordError("이메일과 동일한 비밀번호는 사용할 수 없습니다.")
-            }
             else -> {
-                // [수정] 정상 입력 → 보라색 테두리 유지
                 binding.flPassword.setBackgroundResource(R.drawable.bg_input_field_active)
                 hidePasswordError()
             }
@@ -201,8 +241,8 @@ class SignUpIdPwFragment : Fragment() {
         val password = binding.etPassword.text.toString()
         val passwordConfirm = binding.etPasswordConfirm.text.toString()
 
-        val emailOk = isEmailFormatValid(email) && email != DUPLICATE_EMAIL
-        val passwordOk = isPasswordFormatValid(password) && !isPasswordSameAsEmail(password, email)
+        val emailOk = isEmailFormatValid(email) && email != duplicateEmail
+        val passwordOk = isPasswordFormatValid(password)
         val confirmOk = password == passwordConfirm && passwordConfirm.isNotEmpty()
 
         viewModel.onStep2Changed(
@@ -216,8 +256,8 @@ class SignUpIdPwFragment : Fragment() {
         val email = binding.etEmail.text.toString().trim()
         val password = binding.etPassword.text.toString()
         val passwordConfirm = binding.etPasswordConfirm.text.toString()
-        return isEmailFormatValid(email) && email != DUPLICATE_EMAIL
-                && isPasswordFormatValid(password) && !isPasswordSameAsEmail(password, email)
+        return isEmailFormatValid(email) && email != duplicateEmail
+                && isPasswordFormatValid(password)
                 && password == passwordConfirm && passwordConfirm.isNotEmpty()
     }
 
@@ -229,10 +269,6 @@ class SignUpIdPwFragment : Fragment() {
     private fun isPasswordFormatValid(password: String): Boolean {
         val regex = Regex("^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$")
         return regex.matches(password)
-    }
-
-    private fun isPasswordSameAsEmail(password: String, email: String): Boolean {
-        return email.isNotEmpty() && password.equals(email, ignoreCase = true)
     }
 
     private fun setPasswordVisibility(

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep1Fragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep1Fragment.kt
@@ -215,7 +215,14 @@ class SignUpStep1Fragment : Fragment() {
         val gradeIndex = if (selectedGrade != null) {
             selectedGrade!!.replace("학년", "").toIntOrNull() ?: 0
         } else 0
-        val semesterIndex = if (selectedSemester != null) 1 else 0
+        // UI 라벨 → 학기 번호 매핑. 0은 미선택.
+        val semesterIndex = when (selectedSemester) {
+            "1학기" -> 1
+            "여름학기" -> 2
+            "2학기" -> 3
+            "겨울학기" -> 4
+            else -> 0
+        }
         val entranceYear = selectedEntranceYear?.toIntOrNull() ?: 0
 
         viewModel.onStep1Changed(name, gradeIndex, semesterIndex, entranceYear)

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep1Fragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep1Fragment.kt
@@ -7,6 +7,7 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -46,6 +47,16 @@ class SignUpStep1Fragment : Fragment() {
         observeViewModel()
         setupListeners()
         restoreState()
+        // 이메일 인증 완료 후 들어온 화면이므로 뒤로가기를 차단해 인증 화면으로
+        // 돌아가지 못하게 한다.
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    // 아무 동작도 하지 않음 → 현재 화면 유지
+                }
+            }
+        )
     }
 
     // ViewModel에 저장된 값으로 UI 복원

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep2Fragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep2Fragment.kt
@@ -186,7 +186,7 @@ class SignUpStep2Fragment : Fragment() {
             findNavController().popBackStack()
         }
 
-        // 다음 버튼 → Step3로 이동
+        // 서버 저장은 Step5에서 한 번에 처리. 여기는 단순 화면 전환만.
         binding.btnNext.setOnClickListener {
             findNavController().navigate(R.id.action_step2_to_step3)
         }

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep3Fragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep3Fragment.kt
@@ -311,7 +311,6 @@ class SignUpStep3Fragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.step3Valid.collect { valid ->
-                    // step2 와 동일한 토글 패턴: 배경/글씨색을 함께 스왑
                     binding.btnNext.isEnabled = valid
                     if (valid) {
                         binding.btnNext.setBackgroundResource(R.drawable.bg_btn_primary)
@@ -353,6 +352,7 @@ class SignUpStep3Fragment : Fragment() {
         binding.btnPrev.setOnClickListener {
             findNavController().popBackStack()
         }
+        // 서버 저장은 Step5에서 한 번에 처리. 여기는 단순 화면 전환만.
         binding.btnNext.setOnClickListener {
             findNavController().navigate(R.id.action_step3_to_step4)
         }

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep4Fragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep4Fragment.kt
@@ -76,6 +76,7 @@ class SignUpStep4Fragment : Fragment() {
         binding.btnPrev.setOnClickListener {
             findNavController().popBackStack()
         }
+        // 서버 저장은 Step5에서 한 번에 처리. 여기는 단순 화면 전환만.
         binding.btnNext.setOnClickListener {
             findNavController().navigate(com.ultimatejw.mjcn.R.id.action_step4_to_step5)
         }
@@ -84,7 +85,8 @@ class SignUpStep4Fragment : Fragment() {
     /** + 버튼 클릭 시: 미선택이면 추가, 선택 상태면 해제 */
     private fun toggleCourse(course: Course) {
         if (viewModel.findSelectedCourse(course.name) == null) {
-            viewModel.addSelectedCourse(course.name)
+            // meta(전공/교양 분류)를 같이 저장 → Step5 일괄 저장 시 category 결정에 사용.
+            viewModel.addSelectedCourse(course.name, course.meta)
         } else {
             viewModel.removeSelectedCourse(course.name)
         }
@@ -97,21 +99,50 @@ class SignUpStep4Fragment : Fragment() {
     }
 
     private fun showGradePicker(course: Course) {
-        val grades = listOf("A+", "A0", "B+", "B0", "C+", "C0", "D+", "D0", "F", "P")
-        val currentGrade = viewModel.findSelectedCourse(course.name)?.grade
+        val isChapel = course.name == CHAPEL_COURSE_NAME
+        val items = if (isChapel) {
+            listOf("1", "2", "3", "4")
+        } else {
+            listOf("A+", "A0", "B+", "B0", "C+", "C0", "D+", "D0", "F", "P")
+        }
+        val title = getString(
+            if (isChapel) com.ultimatejw.mjcn.R.string.picker_chapel_count
+            else com.ultimatejw.mjcn.R.string.picker_grade_select
+        )
+        val current = viewModel.findSelectedCourse(course.name)?.grade
         ListPickerBottomSheet.newInstance(
-            title = getString(com.ultimatejw.mjcn.R.string.picker_grade_select),
-            items = grades,
-            selectedItem = currentGrade
+            title = title,
+            items = items,
+            selectedItem = current
         ) { selected ->
             viewModel.setCourseGrade(course.name, selected)
             refreshCourseList()
+            updateNextButton()
         }.show(childFragmentManager, "grade_picker")
     }
 
     private fun refreshLists() {
         refreshChipList()
         refreshCourseList()
+        updateNextButton()
+    }
+
+    /**
+     * 채플이 선택되었지만 이수 횟수가 입력되지 않은 경우에만 다음 버튼을 비활성화한다.
+     * 그 외의 모든 상태(미선택 / 선택+횟수 입력됨)에서는 활성.
+     */
+    private fun updateNextButton() {
+        val chapel = viewModel.findSelectedCourse(CHAPEL_COURSE_NAME)
+        val chapelCountMissing = chapel != null && chapel.grade.isNullOrBlank()
+        val enabled = !chapelCountMissing
+        binding.btnNext.isEnabled = enabled
+        if (enabled) {
+            binding.btnNext.setBackgroundResource(com.ultimatejw.mjcn.R.drawable.bg_btn_primary)
+            binding.btnNext.setTextColor(requireContext().getColor(com.ultimatejw.mjcn.R.color.white))
+        } else {
+            binding.btnNext.setBackgroundResource(com.ultimatejw.mjcn.R.drawable.bg_btn_disabled)
+            binding.btnNext.setTextColor(requireContext().getColor(com.ultimatejw.mjcn.R.color.text_disabled))
+        }
     }
 
     private fun refreshChipList() {
@@ -134,22 +165,47 @@ class SignUpStep4Fragment : Fragment() {
         val majorMeta = "반도체 ICT대학 · 컴퓨터정보통신공학부 · 컴퓨터공학과"
         val liberalArtsMeta = "자연캠퍼스 교양"
         return listOf(
-            Course("4차산업혁명과기업가정신", majorMeta),
-            Course("AI프로그래밍", majorMeta),
+            // 전공
+            Course("C언어프로그래밍", majorMeta),
+            Course("공학입문설계", majorMeta),
+            Course("객체지향프로그래밍1", majorMeta),
             Course("객체지향프로그래밍2", majorMeta),
-            Course("공개SW실무", majorMeta),
-            Course("그래프신경망과빅데이터", majorMeta),
-            Course("기계학습", majorMeta),
-            Course("데이터베이스", majorMeta),
-            Course("데이터베이스설계", majorMeta),
-            Course("딥러닝", majorMeta),
-            Course("모바일프로그래밍", majorMeta),
-            Course("블록체인", majorMeta),
+            Course("컴퓨터하드웨어", majorMeta),
+            Course("자료구조", majorMeta),
+            Course("웹프로그래밍", majorMeta),
+            Course("팀프로젝트1", majorMeta),
+            Course("컴퓨터 보안", majorMeta),
+            Course("컴퓨터교육론", majorMeta),
+            Course("운영체제", majorMeta),
             Course("소프트웨어공학", majorMeta),
-            Course("영어 1", liberalArtsMeta),
-            Course("영어 2", liberalArtsMeta),
-            Course("영어회화 1", liberalArtsMeta),
-            Course("영어회화 2", liberalArtsMeta)
+            Course("공개SW실무", majorMeta),
+            Course("알고리즘", majorMeta),
+            Course("시스템프로그래밍", majorMeta),
+            Course("프로그래밍언어", majorMeta),
+            Course("모바일프로그래밍", majorMeta),
+            // 교양
+            Course(CHAPEL_COURSE_NAME, liberalArtsMeta),
+            Course("기초미적분학", liberalArtsMeta),
+            Course("영어1", liberalArtsMeta),
+            Course("영어2", liberalArtsMeta),
+            Course("영어회화1", liberalArtsMeta),
+            Course("영어회화2", liberalArtsMeta),
+            Course("물리학1", liberalArtsMeta),
+            Course("물리학실험1", liberalArtsMeta),
+            Course("미적분학1", liberalArtsMeta),
+            Course("통계학개론", liberalArtsMeta),
+            Course("기독교와문화", liberalArtsMeta),
+            Course("이산수학개론", liberalArtsMeta),
+            Course("예술과창조성", liberalArtsMeta),
+            Course("발표와토의", liberalArtsMeta),
+            Course("공학수학1", liberalArtsMeta),
+            Course("파이썬프로그래밍입문", liberalArtsMeta),
+            Course("파이썬을활용한데이터분석과인공지능", liberalArtsMeta),
+            Course("선형대수학개론", liberalArtsMeta),
+            Course("세계화와사회변화", liberalArtsMeta),
+            Course("성서와인간이해", liberalArtsMeta),
+            Course("철학과인간", liberalArtsMeta),
+            Course("현대사회와기독교윤리", liberalArtsMeta)
         )
     }
 

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep5Fragment.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpStep5Fragment.kt
@@ -8,11 +8,16 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.ultimatejw.mjcn.R
 import com.ultimatejw.mjcn.databinding.FragmentSignupStep5Binding
+import com.ultimatejw.mjcn.utils.showToast
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class SignUpStep5Fragment : Fragment() {
@@ -42,6 +47,32 @@ class SignUpStep5Fragment : Fragment() {
         setupSearch()
         setupButtons()
         refreshLists()
+        observeStepSave()
+    }
+
+    private fun observeStepSave() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.stepSaveResult.collect { result ->
+                    when (result) {
+                        is StepSaveResult.Success -> if (result.step == 5) {
+                            findNavController().navigate(R.id.action_step5_to_complete)
+                        }
+                        is StepSaveResult.Failure -> if (result.step == 5) {
+                            showToast(result.message)
+                            binding.btnNext.isEnabled = true
+                        }
+                    }
+                }
+            }
+        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.isStepSaveLoading.collect { loading ->
+                    binding.btnNext.isEnabled = !loading
+                }
+            }
+        }
     }
 
     private fun setupRecyclers() {
@@ -76,13 +107,14 @@ class SignUpStep5Fragment : Fragment() {
             findNavController().popBackStack()
         }
         binding.btnNext.setOnClickListener {
-            findNavController().navigate(R.id.action_step5_to_complete)
+            // Step1~5 사용자 입력을 일괄 저장 + is_onboarding_completed=true 마킹.
+            viewModel.saveAllAndCompleteOnboarding()
         }
     }
 
     private fun toggleCourse(course: Course) {
         if (viewModel.findCurrentCourse(course.name) == null) {
-            viewModel.addCurrentCourse(course.name)
+            viewModel.addCurrentCourse(course.name, course.meta)
         } else {
             viewModel.removeCurrentCourse(course.name)
         }
@@ -117,20 +149,17 @@ class SignUpStep5Fragment : Fragment() {
 
     private fun buildCourseData(): List<Course> {
         val majorMeta = "반도체 ICT대학 · 컴퓨터정보통신공학부 · 컴퓨터공학과"
+        val liberalArtsMeta = "자연캠퍼스 교양"
         val code = "0727"
         return listOf(
-            Course("4차산업혁명과기업가정신", majorMeta, code),
-            Course("AI프로그래밍", majorMeta, code),
-            Course("객체지향프로그래밍2", majorMeta, code),
-            Course("공개SW실무", majorMeta, code),
-            Course("그래프신경망과빅데이터", majorMeta, code),
+            // 전공
             Course("기계학습", majorMeta, code),
+            Course("캡스톤디자인", majorMeta, code),
+            Course("시스템클라우드보안", majorMeta, code),
             Course("데이터베이스", majorMeta, code),
-            Course("데이터베이스설계", majorMeta, code),
-            Course("딥러닝", majorMeta, code),
-            Course("모바일프로그래밍", majorMeta, code),
-            Course("블록체인", majorMeta, code),
-            Course("소프트웨어공학", majorMeta, code)
+            // 교양
+            Course("4차산업혁명과미래사회진로선택", liberalArtsMeta),
+            Course("현대사회와기독교윤리", liberalArtsMeta)
         )
     }
 

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpViewModel.kt
@@ -1,14 +1,43 @@
 package com.ultimatejw.mjcn.ui.auth.signup
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.ultimatejw.mjcn.data.repository.AuthApiException
+import com.ultimatejw.mjcn.domain.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+sealed class SignupResult {
+    data object Success : SignupResult()
+    data class EmailError(val message: String, val rejectedEmail: String) : SignupResult()
+    data class PasswordError(val message: String) : SignupResult()
+    data class PasswordConfirmError(val message: String) : SignupResult()
+    data class GeneralError(val message: String) : SignupResult()
+}
+
+sealed class VerifyEmailResult {
+    data object Success : VerifyEmailResult()
+    data class Failure(val message: String) : VerifyEmailResult()
+}
+
+sealed class ResendResult {
+    data object Success : ResendResult()
+    data class Failure(val message: String) : ResendResult()
+}
+
 @HiltViewModel
-class SignUpViewModel @Inject constructor() : ViewModel() {
+class SignUpViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
 
     // Step 1
     var name: String = ""
@@ -80,6 +109,21 @@ class SignUpViewModel @Inject constructor() : ViewModel() {
     private val _majorStepValid = MutableStateFlow(false)
     val majorStepValid: StateFlow<Boolean> = _majorStepValid.asStateFlow()
 
+    private val _isSignupLoading = MutableStateFlow(false)
+    val isSignupLoading: StateFlow<Boolean> = _isSignupLoading.asStateFlow()
+
+    private val _signupResult = Channel<SignupResult>(Channel.BUFFERED)
+    val signupResult = _signupResult.receiveAsFlow()
+
+    private val _isVerifyLoading = MutableStateFlow(false)
+    val isVerifyLoading: StateFlow<Boolean> = _isVerifyLoading.asStateFlow()
+
+    private val _verifyResult = Channel<VerifyEmailResult>(Channel.BUFFERED)
+    val verifyResult = _verifyResult.receiveAsFlow()
+
+    private val _resendResult = Channel<ResendResult>(Channel.BUFFERED)
+    val resendResult = _resendResult.receiveAsFlow()
+
     companion object {
         private val NAME_REGEX = Regex("^[가-힣a-zA-Z]{2,10}$")
         const val OTHER_INTEREST_LABEL = "기타(직접 입력)"
@@ -134,5 +178,100 @@ class SignUpViewModel @Inject constructor() : ViewModel() {
         val otherTextValid = otherTextLen in OTHER_INTEREST_MIN_LENGTH..OTHER_INTEREST_MAX_LENGTH
         // 기타가 선택된 경우 다른 칩 동반 여부와 무관하게 입력 텍스트가 2~100자여야 함
         _step3Valid.value = hasSelection && (!otherSelected || otherTextValid)
+    }
+
+    fun requestSignup(email: String, password: String, passwordConfirm: String) {
+        if (_isSignupLoading.value) return
+        viewModelScope.launch {
+            _isSignupLoading.value = true
+            val result = authRepository.signup(email, password, passwordConfirm)
+            _isSignupLoading.value = false
+            result
+                .onSuccess {
+                    this@SignUpViewModel.email = email
+                    this@SignUpViewModel.password = password
+                    _signupResult.send(SignupResult.Success)
+                }
+                .onFailure { throwable ->
+                    val errorBody = (throwable as? AuthApiException)?.errorBody.orEmpty()
+                    val fallback = throwable.message ?: "회원가입에 실패했습니다."
+                    _signupResult.send(parseSignupErrorBody(errorBody, email, fallback))
+                }
+        }
+    }
+
+    private fun parseSignupErrorBody(body: String, email: String, fallback: String): SignupResult {
+        if (body.isBlank()) return SignupResult.GeneralError(fallback)
+        return try {
+            val json = JsonParser.parseString(body).asJsonObject
+            val emailMsg = json.firstStringIn("email")
+            val passwordMsg = json.firstStringIn("password")
+            val passwordConfirmMsg = json.firstStringIn("password_confirm")
+            val nonFieldMsg = json.firstStringIn("non_field_errors")
+            val detailMsg = json.get("detail")?.takeIf { !it.isJsonNull }?.asString
+            when {
+                emailMsg != null -> SignupResult.EmailError(emailMsg, email)
+                passwordMsg != null -> SignupResult.PasswordError(passwordMsg)
+                passwordConfirmMsg != null -> SignupResult.PasswordConfirmError(passwordConfirmMsg)
+                nonFieldMsg != null -> SignupResult.GeneralError(nonFieldMsg)
+                detailMsg != null -> SignupResult.GeneralError(detailMsg)
+                else -> SignupResult.GeneralError(fallback)
+            }
+        } catch (_: Exception) {
+            SignupResult.GeneralError(fallback)
+        }
+    }
+
+    private fun JsonObject.firstStringIn(key: String): String? {
+        val element = get(key) ?: return null
+        if (element.isJsonNull) return null
+        return when {
+            element.isJsonArray -> (element as JsonArray)
+                .takeIf { it.size() > 0 }
+                ?.get(0)
+                ?.takeIf { !it.isJsonNull }
+                ?.asString
+            element.isJsonPrimitive -> element.asString
+            else -> null
+        }
+    }
+
+    fun verifyEmail(code: String) {
+        if (_isVerifyLoading.value) return
+        val targetEmail = email
+        if (targetEmail.isBlank()) {
+            viewModelScope.launch {
+                _verifyResult.send(VerifyEmailResult.Failure("이메일 정보가 없습니다. 이전 단계부터 다시 진행해주세요."))
+            }
+            return
+        }
+        viewModelScope.launch {
+            _isVerifyLoading.value = true
+            val result = authRepository.verifyEmail(targetEmail, code)
+            _isVerifyLoading.value = false
+            result
+                .onSuccess { _verifyResult.send(VerifyEmailResult.Success) }
+                .onFailure {
+                    _verifyResult.send(VerifyEmailResult.Failure("인증 코드가 일치하지 않습니다."))
+                }
+        }
+    }
+
+    fun resendVerification() {
+        val targetEmail = email
+        if (targetEmail.isBlank()) {
+            viewModelScope.launch {
+                _resendResult.send(ResendResult.Failure("이메일 정보가 없습니다. 이전 단계부터 다시 진행해주세요."))
+            }
+            return
+        }
+        viewModelScope.launch {
+            val result = authRepository.resendVerification(targetEmail)
+            result
+                .onSuccess { _resendResult.send(ResendResult.Success) }
+                .onFailure {
+                    _resendResult.send(ResendResult.Failure("인증 코드 재전송에 실패했습니다."))
+                }
+        }
     }
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignUpViewModel.kt
@@ -5,8 +5,13 @@ import androidx.lifecycle.viewModelScope
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.ultimatejw.mjcn.data.local.TokenStore
 import com.ultimatejw.mjcn.data.repository.AuthApiException
 import com.ultimatejw.mjcn.domain.repository.AuthRepository
+import com.ultimatejw.mjcn.domain.repository.CourseHistoryRepository
+import com.ultimatejw.mjcn.domain.repository.CurrentCourseRepository
+import com.ultimatejw.mjcn.domain.repository.InterestRepository
+import com.ultimatejw.mjcn.domain.repository.ProfileRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,9 +39,26 @@ sealed class ResendResult {
     data class Failure(val message: String) : ResendResult()
 }
 
+/** 인증 직후 자동 로그인 결과. */
+sealed class AutoLoginResult {
+    data object Success : AutoLoginResult()
+    data class Failure(val message: String) : AutoLoginResult()
+}
+
+/** 각 단계별 서버 저장 결과. */
+sealed class StepSaveResult {
+    data class Success(val step: Int) : StepSaveResult()
+    data class Failure(val step: Int, val message: String) : StepSaveResult()
+}
+
 @HiltViewModel
 class SignUpViewModel @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val profileRepository: ProfileRepository,
+    private val interestRepository: InterestRepository,
+    private val courseHistoryRepository: CourseHistoryRepository,
+    private val currentCourseRepository: CurrentCourseRepository,
+    private val tokenStore: TokenStore
 ) : ViewModel() {
 
     // Step 1
@@ -67,9 +89,9 @@ class SignUpViewModel @Inject constructor(
     fun findSelectedCourse(name: String): SelectedCourse? =
         selectedCourses.firstOrNull { it.name == name }
 
-    fun addSelectedCourse(name: String) {
+    fun addSelectedCourse(name: String, meta: String = "") {
         if (findSelectedCourse(name) == null) {
-            selectedCourses.add(SelectedCourse(name))
+            selectedCourses.add(SelectedCourse(name = name, meta = meta))
         }
     }
 
@@ -87,9 +109,9 @@ class SignUpViewModel @Inject constructor(
     fun findCurrentCourse(name: String): SelectedCourse? =
         selectedCurrentCourses.firstOrNull { it.name == name }
 
-    fun addCurrentCourse(name: String) {
+    fun addCurrentCourse(name: String, meta: String = "") {
         if (findCurrentCourse(name) == null) {
-            selectedCurrentCourses.add(SelectedCourse(name))
+            selectedCurrentCourses.add(SelectedCourse(name = name, meta = meta))
         }
     }
 
@@ -123,6 +145,15 @@ class SignUpViewModel @Inject constructor(
 
     private val _resendResult = Channel<ResendResult>(Channel.BUFFERED)
     val resendResult = _resendResult.receiveAsFlow()
+
+    private val _autoLoginResult = Channel<AutoLoginResult>(Channel.BUFFERED)
+    val autoLoginResult = _autoLoginResult.receiveAsFlow()
+
+    private val _stepSaveResult = Channel<StepSaveResult>(Channel.BUFFERED)
+    val stepSaveResult = _stepSaveResult.receiveAsFlow()
+
+    private val _isStepSaveLoading = MutableStateFlow(false)
+    val isStepSaveLoading: StateFlow<Boolean> = _isStepSaveLoading.asStateFlow()
 
     companion object {
         private val NAME_REGEX = Regex("^[가-힣a-zA-Z]{2,10}$")
@@ -273,5 +304,126 @@ class SignUpViewModel @Inject constructor(
                     _resendResult.send(ResendResult.Failure("인증 코드 재전송에 실패했습니다."))
                 }
         }
+    }
+
+    /**
+     * 인증 직후 자동 로그인. 이메일/비밀번호는 회원가입 시 저장해둔 값을 사용.
+     * 성공하면 TokenStore에 JWT가 저장되어 이후 API에 자동으로 첨부된다.
+     */
+    fun performAutoLogin() {
+        val targetEmail = email
+        val targetPassword = password
+        if (targetEmail.isBlank() || targetPassword.isBlank()) {
+            viewModelScope.launch {
+                _autoLoginResult.send(AutoLoginResult.Failure("자동 로그인에 필요한 정보가 없습니다."))
+            }
+            return
+        }
+        viewModelScope.launch {
+            authRepository.login(targetEmail, targetPassword)
+                .onSuccess { _autoLoginResult.send(AutoLoginResult.Success) }
+                .onFailure { throwable ->
+                    val msg = (throwable as? AuthApiException)?.let { "자동 로그인 실패: HTTP ${it.code}" }
+                        ?: "자동 로그인에 실패했습니다."
+                    _autoLoginResult.send(AutoLoginResult.Failure(msg))
+                }
+        }
+    }
+
+    /**
+     * Step1 ~ Step5 사용자 입력을 한 번에 서버에 저장.
+     * 중간 단계에서 부분 저장을 하면 사용자가 뒤로 가기 → 다시 진행 시 중복 레코드/유니크 제약 위반으로
+     * 500이 나는 문제가 있어, Step5 "다음" 클릭 시점에만 일괄 POST/PATCH를 수행한다.
+     *
+     * 순서:
+     *   1) PATCH /profile/  (Step1 + Step2 정보)
+     *   2) POST /interests/ × N  (Step3 관심분야)
+     *   3) POST /course-history/ × N  (Step4 수강이력)
+     *   4) POST /current-courses/ × N  (Step5 현재 수강 과목)
+     *   5) PATCH /profile/ is_onboarding_completed=true
+     *
+     * 중간에 실패하면 즉시 중단하고 Failure 발행. 사용자는 Step1부터 다시 시작해야 한다.
+     */
+    fun saveAllAndCompleteOnboarding() {
+        if (_isStepSaveLoading.value) return
+        viewModelScope.launch {
+            _isStepSaveLoading.value = true
+            try {
+                // 1) Step1 + Step2 → PATCH /profile/
+                val (gradYear, gradMonth) = parseGraduationTerm(graduationTerm)
+                val combinedMajor = listOf(college, department, major)
+                    .filter { it.isNotBlank() }
+                    .joinToString(" · ")
+                val profileResult = profileRepository.patchProfile(
+                    name = name.takeIf { it.isNotBlank() },
+                    grade = grade.takeIf { it > 0 },
+                    semester = semester.takeIf { it > 0 },
+                    admissionYear = entranceYear.takeIf { it > 0 },
+                    graduationYear = gradYear,
+                    graduationMonth = gradMonth,
+                    major = combinedMajor.takeIf { it.isNotBlank() }
+                )
+                if (profileResult.isFailure) {
+                    emitFailure(profileResult.exceptionOrNull()!!, "기본 정보 저장에 실패했습니다.")
+                    return@launch
+                }
+
+                // 2) Step3 → POST /interests/
+                for (label in selectedInterests) {
+                    val isOther = label == OTHER_INTEREST_LABEL
+                    val category = if (isOther) "기타" else label
+                    val customText = if (isOther) otherInterestText.trim() else ""
+                    val r = interestRepository.createInterest(category, customText)
+                    if (r.isFailure) {
+                        emitFailure(r.exceptionOrNull()!!, "관심분야 저장에 실패했습니다.")
+                        return@launch
+                    }
+                }
+
+                // 3) Step4 (course-history) / 4) Step5 (current-courses) 는
+                //    서버의 Course 마스터 테이블과 course_code FK 매칭이 필요해
+                //    placeholder 코드로는 IntegrityError → 500 이 발생함을 확인.
+                //    백엔드와 course_code 매핑 확정 전까지 저장은 보류.
+                //    사용자가 선택한 selectedCourses / selectedCurrentCourses 는
+                //    ViewModel 메모리에 남아 있으므로 추후 연결만 하면 됨.
+
+                // 5) 온보딩 완료 마킹
+                profileRepository.patchProfile(isOnboardingCompleted = true)
+                    .onSuccess {
+                        tokenStore.setOnboardingCompleted(true)
+                        _stepSaveResult.send(StepSaveResult.Success(step = 5))
+                    }
+                    .onFailure { t ->
+                        emitFailure(t, "온보딩 완료 처리에 실패했습니다.")
+                    }
+            } finally {
+                _isStepSaveLoading.value = false
+            }
+        }
+    }
+
+    private suspend fun emitFailure(t: Throwable, fallback: String) {
+        _stepSaveResult.send(StepSaveResult.Failure(5, errorMessage(t, fallback)))
+    }
+
+    /** "2026년 2월" → 2026, 2 / "선택 안 함" 또는 빈 문자열 → null, null */
+    private fun parseGraduationTerm(term: String?): Pair<Int?, Int?> {
+        if (term.isNullOrBlank() || term == "선택 안 함") return null to null
+        val year = Regex("(\\d{4})년").find(term)?.groupValues?.getOrNull(1)?.toIntOrNull()
+        val month = Regex("(\\d{1,2})월").find(term)?.groupValues?.getOrNull(1)?.toIntOrNull()
+        return year to month
+    }
+
+    private fun errorMessage(t: Throwable, fallback: String): String {
+        val api = t as? AuthApiException ?: return t.message ?: fallback
+        // 응답 본문은 Logcat에도 풀로 남겨 토스트가 잘릴 때 확인 가능하게 함.
+        android.util.Log.e(
+            "SignUpViewModel",
+            "API error: HTTP ${api.code}, body=${api.errorBody}"
+        )
+        val detail = api.errorBody.takeIf { it.isNotBlank() }?.let { body ->
+            " - ${body.take(200)}"
+        }.orEmpty()
+        return "$fallback (HTTP ${api.code})$detail"
     }
 }

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignupEmailSentDialog.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/auth/signup/SignupEmailSentDialog.kt
@@ -1,0 +1,73 @@
+package com.ultimatejw.mjcn.ui.auth.signup
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.util.TypedValue
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Gravity
+import android.view.WindowManager
+import android.widget.Button
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.ultimatejw.mjcn.R
+
+class SignupEmailSentDialog : DialogFragment() {
+
+    companion object {
+        const val REQUEST_KEY = "SignupEmailSentDialog.REQUEST_KEY"
+        const val RESULT_CONFIRMED = "confirmed"
+        const val TAG = "SignupEmailSentDialog"
+
+        private const val HORIZONTAL_MARGIN_DP = 18f
+        // 박스가 187dp일 때 중앙 위치 기준으로, 203dp(16dp 늘림)로 바뀐 후에도
+        // 박스 위쪽이 원래 위치 그대로 유지되도록 박스를 8dp 아래로 내림.
+        private const val VERTICAL_OFFSET_DP = 8f
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.dialog_signup_email_sent, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<Button>(R.id.btn_dialog_confirm).setOnClickListener {
+            setFragmentResult(REQUEST_KEY, bundleOf(RESULT_CONFIRMED to true))
+            dismiss()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.apply {
+            setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            // 뒷배경 어둡게 (스크림)
+            addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+            val params = attributes
+            params.dimAmount = 0.5f
+            params.gravity = Gravity.CENTER
+            params.y = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                VERTICAL_OFFSET_DP,
+                resources.displayMetrics
+            ).toInt()
+            attributes = params
+
+            val marginPx = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                HORIZONTAL_MARGIN_DP,
+                resources.displayMetrics
+            ).toInt()
+            val screenWidth = resources.displayMetrics.widthPixels
+            val width = screenWidth - 2 * marginPx
+            setLayout(width, WindowManager.LayoutParams.WRAP_CONTENT)
+        }
+    }
+}

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/splash/SplashActivity.kt
@@ -11,7 +11,6 @@ import com.ultimatejw.mjcn.ui.auth.AuthActivity
 import com.ultimatejw.mjcn.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 @SuppressLint("CustomSplashScreen")
@@ -28,8 +27,9 @@ class SplashActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             delay(1500)
-            val isLoggedIn = viewModel.isLoggedIn.first()
-            val intent = if (isLoggedIn) {
+            // 온보딩 미완료 사용자는 로그인 화면을 거쳐 멈춘 단계로 재개시킨다.
+            val toMain = viewModel.shouldGoToMain()
+            val intent = if (toMain) {
                 Intent(this@SplashActivity, MainActivity::class.java)
             } else {
                 Intent(this@SplashActivity, AuthActivity::class.java)

--- a/app/src/main/java/com/ultimatejw/mjcn/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/ultimatejw/mjcn/ui/splash/SplashViewModel.kt
@@ -1,14 +1,27 @@
 package com.ultimatejw.mjcn.ui.splash
 
 import androidx.lifecycle.ViewModel
+import com.ultimatejw.mjcn.data.local.TokenStore
 import com.ultimatejw.mjcn.domain.usecase.user.GetLoginStateUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     private val getLoginState: GetLoginStateUseCase,
+    private val tokenStore: TokenStore,
 ) : ViewModel() {
     val isLoggedIn: Flow<Boolean> = getLoginState()
+
+    /**
+     * 메인 화면으로 바로 들어갈 조건: isLoggedIn=true AND onboarding_completed=true.
+     * 그 외(처음 실행 / 온보딩 미완료)는 로그인/회원가입 화면으로 보낸다.
+     */
+    suspend fun shouldGoToMain(): Boolean {
+        val loggedIn = isLoggedIn.first()
+        if (!loggedIn) return false
+        return tokenStore.isOnboardingCompleted()
+    }
 }

--- a/app/src/main/res/drawable/bg_dialog_rounded.xml
+++ b/app/src/main/res/drawable/bg_dialog_rounded.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <corners android:radius="32dp" />
+</shape>

--- a/app/src/main/res/layout/dialog_signup_email_sent.xml
+++ b/app/src/main/res/layout/dialog_signup_email_sent.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_dialog_rounded">
+
+    <TextView
+        android:id="@+id/tv_dialog_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="인증 코드를 이메일로 발송했습니다."
+        android:textColor="@color/text_primary"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_dialog_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="18dp"
+        android:text="이메일을 확인해주세요."
+        android:textColor="@color/text_primary"
+        android:textSize="14sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_dialog_title" />
+
+    <Button
+        android:id="@+id/btn_dialog_confirm"
+        android:layout_width="0dp"
+        android:layout_height="52dp"
+        android:layout_marginStart="15dp"
+        android:layout_marginEnd="15dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginBottom="16dp"
+        android:background="@drawable/bg_btn_primary"
+        android:fontFamily="sans-serif-medium"
+        android:text="확인"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_dialog_subtitle"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_auth.xml
+++ b/app/src/main/res/navigation/nav_auth.xml
@@ -11,6 +11,28 @@
         <action
             android:id="@+id/action_login_to_signup"
             app:destination="@id/signUpIdPwFragment" />
+        <!-- 로그인 후 온보딩 미완료 상태에서 멈춘 지점으로 직접 이동.
+             popUpTo로 로그인 화면을 백스택에서 제거해 뒤로가기로 돌아오지 못하게 한다. -->
+        <action
+            android:id="@+id/action_login_to_step1"
+            app:destination="@id/signUpStep1Fragment"
+            app:popUpTo="@id/loginFragment"
+            app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_login_to_step3"
+            app:destination="@id/signUpStep3Fragment"
+            app:popUpTo="@id/loginFragment"
+            app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_login_to_step4"
+            app:destination="@id/signUpStep4Fragment"
+            app:popUpTo="@id/loginFragment"
+            app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_login_to_step5"
+            app:destination="@id/signUpStep5Fragment"
+            app:popUpTo="@id/loginFragment"
+            app:popUpToInclusive="true" />
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,9 @@
     <string name="signup_course_search_hint">전체 과목 이름으로 검색</string>
     <string name="signup_course_grade_hint">성적(선택)</string>
     <string name="picker_grade_select">성적 선택</string>
+    <!-- 채플 전용 -->
+    <string name="signup_chapel_count_hint">이수 횟수 입력(필수)</string>
+    <string name="picker_chapel_count">이수 횟수 선택</string>
 
     <!-- SignUp Step5: 현재 수강 과목 -->
     <string name="signup_current_title">현재 수강 과목</string>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">3.34.185.127</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION

회원가입  step1~5 데이터 처리  -> 일괄저장
(사용자가 가입 도중 나가면 로그인 후 step1부터 시작해야함)

- course-history / current-courses 저장은 비활성 상태.  ( course_code 매핑 결정되면 saveAllAndCompleteOnboarding
   내부 주석 블록을 다시 켜면 됨. ViewModel의 selectedCourses / selectedCurrentCourses에는 사용자 선택이 그대로
  살아있음. )

수강이력, 수강중인 과목 POST할때  time/day placeholder 는 임시데이터 전송 (나중에 서버수정 필요)